### PR TITLE
Add native DSD playback via SAS offload shim with wire format controls and diagnostics

### DIFF
--- a/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
@@ -57,6 +57,7 @@ import android.os.Bundle
 import android.os.Environment
 import android.provider.DocumentsContract
 import android.provider.MediaStore
+import android.provider.OpenableColumns
 import android.provider.Settings
 import android.util.Log
 import android.os.PowerManager
@@ -2455,7 +2456,7 @@ class MainActivity: FlutterActivity() {
         maxSizeBytes: Long? = null,
     ): String? {
         val uri = Uri.parse(uriString)
-        val normalizedExt = normalizeAudioExtension(extensionHint)
+        val normalizedExt = resolveStagedExtension(uri, extensionHint)
         val stagingDir = java.io.File(cacheDir, "playback_staging").apply { mkdirs() }
         val fileHash = md5(uriString)
         val stagedFile = java.io.File(stagingDir, "$fileHash.$normalizedExt")
@@ -3281,6 +3282,35 @@ class MainActivity: FlutterActivity() {
             "aif", "aiff" -> "aiff"
             "m4a", "alac" -> "m4a"
             else -> ext
+        }
+    }
+
+    // The provider's display name carries the real container extension (e.g.
+    // .dsf/.dff for DSD), which generic mime-derived hints (e.g. "dsd") lose.
+    private fun resolveStagedExtension(uri: Uri, extensionHint: String?): String {
+        val providerExt = try {
+            contentResolver
+                .query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+                ?.use { cursor ->
+                    val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (nameIndex >= 0 && cursor.moveToFirst()) {
+                        cursor.getString(nameIndex)
+                            ?.substringAfterLast('.', "")
+                            ?.lowercase()
+                            ?.ifEmpty { null }
+                    } else {
+                        null
+                    }
+                }
+        } catch (_: Exception) {
+            null
+        }
+
+        // Only trust the provider name when it is a plausible audio extension.
+        return if (providerExt != null && providerExt.length in 2..5 && providerExt.all { it.isLetterOrDigit() }) {
+            providerExt
+        } else {
+            normalizeAudioExtension(extensionHint)
         }
     }
 

--- a/docs/audio/dsd-native-dap-plan.md
+++ b/docs/audio/dsd-native-dap-plan.md
@@ -1,0 +1,382 @@
+# Native DSD on DAP Internal DAC (HiBy R4) — Phased Plan
+
+Goal: make DSF / DFF / WavPack-DSD play as **pure native DSD** through the DAP's
+internal DAC — matching what the stock HiBy Music player achieves — not DoP,
+not PCM decimation.
+
+**Approach (decided after Phase 0 recon):** HiBy's firmware ships a **public
+native shim library** (`libsmartaudioservice.so`, listed in
+`/system/etc/public.libraries.txt` → loadable by any app including
+untrusted_app) that creates framework `AudioTrack`s with
+`AUDIO_FORMAT_DSD_NATIVE`. Stock HiBy Music uses exactly this path. Flick will
+`dlopen` the same shim from Rust and drive it — no SELinux fight, no
+`/dev/snd`, no Kotlin/JNI needed.
+
+**Direct ALSA is dead on the R4**: SELinux `permissive=0` denies
+`untrusted_app` read/search on `/dev/snd` (`audio_device` label). The
+original ALSA-based phases (probe via HW_REFINE, per-DAP ALSA hints, ALSA
+settings UI) are obsolete; kept in git history and summarized in §G/H.
+
+Companion docs: `docs/DSD_ARCHITECTURE.md` (current architecture),
+`docs/audio/usb-dsd-bitperfect-plan.md` (USB `UsbDsdNative` — complete, shipped
+v0.20.4-beta.5+), `docs/DSD_CPP_NATIVE_OUTPUT_PLAN.md` (superseded C++/tinyalsa
+draft).
+
+**Failure policy** (decided): when DSD output mode is `native` and native fails,
+fall back to DoP **and surface the exact failure reason** in diagnostics.
+
+---
+
+## A. Already exists and verified (no reimplementation)
+
+| Area | Where | Why it's right |
+|------|-------|----------------|
+| DSD decode (DSF/DFF/WavPack) | `rust/src/audio/dsd_engine/` (`OPEN_DSD_NATIVE`) | Working — already feeds DoP and USB-native paths. |
+| DSD byte stream access | `dsd_engine/output/mod.rs` | The engine already emits raw DSD bytes for DoP/USB-native; the shim backend re-packs them into 32-bit wire subslots. |
+| Native f32 packing | `dsd_engine/output/mod.rs:185` `pack_native_dsd_f32` | Interleaved frame-major f32s, DSD byte in low 8 bits, per-byte bit-order normalize (`DSD_BIT_REVERSE_OVERRIDE` global). Used by old `DsdNativeBackend`; the shim backend reuses the same normalize plumbing. |
+| USB native DSD packer | `uac2/android_direct.rs` `encode_usb_pcm_slots` | Existing 32-bit-slot packer (BE/LE/bit-reverse variants) — the model for the shim wire packer. |
+| USB native DSD | `uac2/android_direct.rs` (`UsbDsdNative`) | Complete incl. `KNOWN_DSD_QUIRKS`; proves the render-thread + ring + fallback architecture. |
+| Old direct-ALSA DSD ioctl engine | `dsd_alsa_direct.rs` | Kept for rooted/friendly devices (desktops, some ROMs); not usable on the R4 (SELinux). |
+| DSD output mode plumbing | Dart `uac2_preferences_service.dart:12` → `rust_audio_service.dart:315` → `audio_api.rs:59-66` | Enum `{auto, forcePcm, forceDop, native}` already exists end-to-end; `native` option present in UI (`uac2_preferences_screen.dart:1553`). |
+
+## B. Why the R4 currently falls back to DoP (traced)
+
+Two candidate paths both produce the observed log
+(`strategy=DSD DoP`, `dsdTransport=dap-dop`,
+`verifyReason="Native DSD unavailable on this device."` — engine.rs:2030):
+
+1. **Probe said no.** `device.rs:191-238` `classify_device`:
+   `supports_native_dsd = audio_caps ‖ ENCODING_DSD runtime probe ‖ dsd_alsa_probe()`.
+   The ENCODING_DSD probe (`dsd_native_jni.rs`) fails on the R4 HAL;
+   `dsd_alsa_probe()` finds `/dev/snd` nodes but **opening them is SELinux-denied**.
+2. **Open failed.** Native attempted; `DsdNativeBackend::start` errored → engine
+   returns `Err("DSD_NATIVE_FALLBACK:<reason>")` (engine.rs:1834) →
+   `audio_api.rs:994-1007` catches, retries with `DsdNative` excluded → DoP.
+
+Strategy scoring (`strategy.rs`): `UsbDsdNative 115 > DsdNative 110 >
+DapNative 100 > DsdDoP 90`; engine.rs:1510-1522 forces DoP when effective mode is
+DoP; rate overrides at engine.rs:1528-1565.
+
+The fallback reason is currently invisible to Dart diagnostics (needs logcat
+`[DSD-ALSA]` / `[DSD-STRATEGY]`) — gap G3 still applies to the new backend.
+
+## C. Confirmed gaps
+
+| # | Gap | Severity | Location |
+|---|-----|----------|----------|
+| G1 | No true capability probe for the shim path: `supports_native_dsd` must now mean "shim `create_track` succeeded (or is likely to)". Probe = dlopen + create + first write; results not cached per-device with reasons. | High | new `dsd_sas_shim.rs`, `device.rs:191` |
+| G2 | No per-DAP wire hints (bit order, slot endianness) — only USB has a quirk table. Bit order on the R4's DAC is unknown. | High | shim packer |
+| G3 | Native failure reason (`DSD_NATIVE_FALLBACK:<reason>`) never reaches Dart diagnostics — log shows `refusal=none, lastError=none`. | High | `engine.rs:1834`, `audio_api.rs:994` |
+| G4 | Audio-focus/interruption handling on the shim render loop (stop/flush on focus loss, resume on regain). | Med | new backend |
+| G5 | DSD bit order on the R4 DAC unknown; `DSD_BIT_REVERSE_OVERRIDE` is a global, not per-playback. Wrong order ⇒ loud noise. | High | `dsd_engine/output/mod.rs` |
+| G6 | Which DSD rates the shim/HAL accepts (policy table says DSD64..DSD1024 wire rates 88 200..1 411 200) — must be verified per-rate at runtime, not assumed. | Med | shim probe |
+| U0 | **Resolved by Phase 0** — see §G. | — | — |
+
+## D. Phases
+
+### Phase 0 — Device recon  ✅ complete (findings in §G, artifacts in /tmp/opencode/)
+
+SELinux kills direct ALSA; HiBy Music itself runs as `untrusted_app` and uses a
+public shim; full wire protocol + shim ABI reverse-engineered from
+`libsmartaudioservice.so` (see §G.3, §H).
+
+### Phase 1 — Rust shim backend (new transport)  ✅ complete (see §H for corrected ABI)
+
+`rust/src/audio/dsd_sas_shim.rs` — implemented, compiled, verified on device:
+
+- `dlopen("libsmartaudioservice.so")` (public lib — allowed for untrusted_app),
+  `dlsym` `create_track` / `release_track`; `probe_unavailable_reason()` feeds
+  `classify_device`.
+- ABI corrections vs the initial RE (§H): **write is slot `[0x00]`** (slot 0x08
+  is a soft-stop — calling it as write silently kills the track), vtable slots
+  are PLT stubs, the write wrapper **returns `len` unconditionally** when a
+  track exists (real `AudioTrack::write` result is discarded), and
+  `create_track` returns **NULL** if the initial track creation fails.
+- Packer: `pack_wire_frames` — stereo wire frames of `2×g` B (L+R g-byte
+  subslots; `g` = runtime grouping 4/2/1, default **U8** byte-interleaved,
+  calibrated on the R4), 4 runtime bit-order variants (`SasWireVariant`),
+  default `RawBe` (MSB-first). Phase 3 calibrated both axes.
+- Render loop (`dsd_native_backend.rs::dsd_sas_render_loop`): one HAL period
+  per write — 32 768 wire frames = 262 144 B, matching HiBy's golden write
+  granularity; chunk size derived from the probe-verified `write_size`.
+- Probe: create + start + silence (0x69) write ladder
+  (262 144 → 524 288 → 1 048 576 → 2 097 152 B) on a watchdog thread
+  (4 s attempt timeout). Full write ⇒ verified; teardown + DoP fallback reason
+  otherwise. On the R4 the first rung (262 144 B) already succeeds.
+- Verified track internals on R4 (log_track_internals): `transfer=3`
+  (TRANSFER_SHARED — HiBy patched `AudioTrack::write` to accept SHARED on
+  offload tracks), `frameSize=1` (set() forces 1 for non-proportional formats),
+  `status=0`, flags `0x11` DIRECT|COMPRESS_OFFLOAD.
+
+### Phase 2 — Strategy / engine integration  ✅ complete
+
+- Transport selected inside `DsdNativeBackend::start` (SAS offload first, ALSA
+  direct fallback); strategy stays `DsdNative` (score 110 > DoP 90).
+- `device.rs classify_device`: `supports_native_dsd |= sas_shim_available()`.
+- Engine rate override: byte rate (= DSD rate/8) as before; wire rate = /32.
+- `dsd_transport` diagnostic string: `dap-native-offload`
+  (via `native_transport_name()`).
+- **G3 fix done**: `DSD_NATIVE_FALLBACK:<reason>` recorded in
+  `audio_api.rs` (`last_dsd_native_failure`) and surfaced in Dart
+  diagnostics via `verifyReason`.
+- Logging fixes: `assert_android_debug_logging()` re-asserts
+  `log::set_max_level(Debug)` at `audio_init`/`audio_play`/`audio_queue_next`
+  (FRB's bundled android_logger 0.15 clobbers the global max level after
+  init, killing all Rust logs ~0.6 s after boot); `DSD_OUTPUT_MODE` static
+  defaults to Auto so an unsync'd engine cannot silently decimate.
+
+### Phase 3 — Wire-format calibration (G5, G2)  ◐ in progress
+
+- Runtime-selectable packer variant (`SasWireVariant`: RawBe/RawLe/BitRevBe/
+  BitRevLe, default RawBe) implemented; **FRB/Dart exposure shipped
+  2026-08-30** — `audio_set_sas_wire_variant(variant: u8)` → preference
+  `DsdWireVariant` (`dsd_wire_variant`) synced in
+  `_syncDsdTransportOverrides`, plus Settings → Experimental → DSD →
+  **DAP Native Bit Order** (Auto/BE-MSB/LE-MSB/BE-LSB/LE-LSB). The packer
+  reads the variant per wire write, so changes apply live while playing.
+- 2026-08-30 wired-HP A/B: **all four bit-order variants hiss** while stock
+  HiBy Music is silent on the same DSD128 + headphones → the defect is
+  ABOVE bit order (grouping/packing level). Deep RE of `libhibyservice.so`
+  (pulled from the APK) settled it:
+  - Stock logcat: `create_track(5644800, 2, 6, 1)` — same fmt 6 as ours, and
+    the engine write path (`0x4450d8`) is a verbatim `memcpy` (no byte
+    transform anywhere; zero `rbit` in the lib) → wire bytes = decoder
+    output, so the packing difference is ours alone.
+  - Engine drain loop (`0x42bd20`) memsets **0x69** (SACD silence) before
+    stop — our 0x55 was wrong.
+  - Audioserver arithmetic: DSD output opens at `bit_rate/32` Hz with
+    channel mask 0x3 and **4 B per stereo frame** (705 600 B/s for DSD128)
+    = two 16-bit subslots → **U16 (LL|RR) grouping**, not the U32
+    (LLLL|RRRR) we shipped. Grouping is orthogonal to the 4 bit-order
+    variants, which is exactly why all four hissed.
+- Fix shipped 2026-08-30: runtime grouping (`SasWireGrouping` U32/U16/U8)
+  alongside the bit order — `audio_set_sas_wire_grouping` → preference
+  `DsdWireGrouping` (`dsd_wire_grouping`) + Settings → Experimental → DSD →
+  **DAP Native Byte Grouping** (Auto/U32/U16/U8); silence byte 0x69;
+  stock-exact `create_track(bit_rate, 2, 6, 1)`; corrected vtable slot for
+  stopped (0x28, not 0x40 — see §H).
+- **Calibration result (2026-08-30, wired HP):** U8 grouping + MSB-first
+  (LE-MSB ≡ BE-MSB at 1-byte subslots) = **clean playback with a light
+  continuous crackle**; every other combo (U8+LSB, all U16, all U32) =
+  loud hiss. So the wire format is plain byte-interleaved LRLR, MSB-first
+  — the audioserver's 4 B/frame @ wire_rate is 4 interleaved bytes, not
+  two 16-bit subslots (the U16 inference above was wrong).
+- **Crackle root cause + fix (2026-08-30):** `audio_callback`'s
+  silence fills (pause, short ring reads, `try_lock` misses) emit `0.0`,
+  which packs to wire byte `0x00` = sustained DC = pops. Ring headroom is
+  thin (SOURCE_BUFFER_SIZE 480k samples vs 262 144-sample write chunks),
+  so partial reads are routine. Fix: `AudioCallbackData.dsd_wire_silence`
+  flag (set by the DSD native backend around its render thread) makes
+  `fill_silence()` emit `f32::from_bits(0x69)` — the SACD silence byte —
+  on the paused/DoP/passthrough fill paths. PCM outputs keep 0.0.
+- **Defaults baked (2026-08-30):** grouping auto → U8 (Rust
+  `WIRE_GROUPING` default 2, Dart auto→2), bit order auto → BE/MSB.
+- Also 2026-08-30: the diagnostics sheet's "Output rate" row now shows
+  the DSD bit rate (e.g. 2.82 MHz, matching the R4's own indicator)
+  instead of the ÷8/÷16/÷32 transport rate, and matches against any
+  valid transport domain.
+- **Residual-crackle round 2 (2026-08-30):** 0x69 fill improved clarity
+  (zero-fill DC confirmed as a contributor) but a light crackle remained.
+  Two more fixes shipped:
+  1. **DSF/DFF short-read bug (primary):** `read_dsd_bytes` did a single
+     `file.read(buf)`; FUSE storage routinely returns short reads, and a
+     short read not a multiple of the DSF macro block (8192 B) had its
+     tail silently dropped by `deinterleave_sequential_blocks` → channel
+     skew + periodic ticks. Both decoders now loop-read to buffer-full
+     or EOF (dsf_decoder.rs, dff_decoder.rs).
+  2. **Lock-miss full-chunk silence:** the RT callback's plain
+     `sources.try_lock()` missed whenever Dart polled progress → a whole
+     262 144-sample chunk of 0x69 = one pop. `lock_sources_rt()` now
+     yield-retries (≤64) first; both passthrough and DoP branches count
+     `dsd_lock_misses` / `dsd_starved_samples` (AtomicU64) and the SAS
+     render loop logs warn-on-change telemetry
+     (`[DSD-NATIVE] starvation telemetry: …`) so any remaining audibility
+     has a paper trail.
+- **UI readouts fixed (2026-08-30):** UAC2 screens showed the transport
+  domain ("705.6kHz / 8-bit" for a 5.6 MHz DSD128). `Uac2AudioFormat`
+  gained DSD-aware getters (`isDsdStream`, `dsdBitRateHz`, `dsdRateLabel`,
+  `displayRateLabel`, `compactRateLabel`, `bitDepthLabel`); the settings
+  screen rows, preferences subtitle, player-status chips/badges and the
+  status indicator chip now render "5.6 MHz · DSD128" / "1-bit (DSD)".
+  Also: `supportsVerifiedBitPerfect` was missing the `dsd_native` /
+  `dsd_dop` strategies → verified capsule/indicator never lit on the DSD
+  path (fixed in player_service.dart).
+
+### Phase 4 — Settings  ✅ complete (2026-08-30)
+
+- `DsdOutputMode.native` already in UI.
+- Bit-order override shipped: Settings → Experimental → DSD → DAP Native
+  Bit Order (Auto/BE-MSB/LE-MSB/BE-LSB/LE-LSB), persisted via
+  `uac2_preferences_service.dart` (`dsd_wire_variant`), synced via
+  `rust_audio_service.dart` `_syncDsdTransportOverrides` beside the DSD
+  output mode; applies immediately to the next wire write for live A/B.
+- Byte-grouping override shipped 2026-08-30: DAP Native Byte Grouping
+  (Auto/U32/U16/U8, `dsd_wire_grouping`), same live-apply plumbing.
+
+### Phase 5 — Verification  ◐ in progress
+
+2026-08-30 first native-DSD stream ACHIEVED (speaker route): our client track
+(pid Flick) visible in `dumpsys media.audio_flinger` — fmt `1A000001`,
+srate 176400, FrmCnt 32768, offload thread, Active — byte-identical to HiBy's
+golden capture. Playback looped (LoopMode.all) across track end with a clean
+engine rebuild; transient `Resampled fallback` diagnostics line during the
+rebuild window is normal, final state `strategy=DSD native … dsdTransport=
+dap-native-offload … bitPerfect=true`.
+
+**Open issue (routing):** with no wired headphones plugged, policy routes the
+offload output to SPEAKER (0x2) and the HAL does NOT throttle — the frames
+counter advances ~5.4 M fps (30× real time), the ring drains at decoder speed
+(song of 326 956 ms "finished" in ~208 s) and audio is discarded/garbage.
+Golden capture proves the WIRED_HEADPHONE (0x8) route paces exactly
+176 400 fps. ~~Next: plug headphones, re-verify pacing + audibility.~~
+2026-08-30: wired-HP route re-verified — pacing correct, HiBy's rate
+indicator shows 5.6 MHz (native DSD128 confirmed end-to-end); remaining
+defect is the wire packing (hiss on all four bit-order variants →
+grouping-level, see Phase 3).
+
+Remaining: E.2 with headphones, E.3 bit order, E.4 regression matrix.
+
+## E. Verification procedures
+
+### E.1 Framework-state readback (primary)
+
+`/proc/asound` is SELinux-blocked, so verify via framework dumps:
+
+```sh
+D="-s 764b099f"
+adb $D shell dumpsys media.audio_flinger   # expect track fmt 1A000001, srate=bitrate/32, FrmCnt 32768 on offload thread (AudioOut_18B5)
+adb $D shell dumpsys media.audio_policy    # expect routing to compressed_offload output
+adb $D logcat -d -s audio_hw:V audioflinger:V
+```
+
+Success = our track row matches HiBy's golden capture (§G.3): format
+`0x1A000001`, rate `bit_rate/32`, offload thread, wired-HP device.
+
+### E.2 Golden-reference A/B
+
+1. Play Chiquitita DSD128 in HiBy Music → `dumpsys media.audio_flinger`
+   (golden: AudioOut_18B5, fmt 1A000001 srate 176400 FrmCnt 32768).
+2. Same file in Flick, native mode → same capture.
+3. Identical fmt + srate + thread type ⇒ driving the DAC exactly like the
+   vendor player. Bit order only affects audible correctness → E.3.
+
+### E.3 Bit-order sanity
+
+Kernel/HAL accepts any bit order; wrong order = loud static. Quiet solo piano
+DSD64; flip variant if noisy; confirm silence floor A/B vs stock player.
+Remaining: confirm the short-read + lock-retry fixes remove the residual
+light crackle on U8+MSB (watch for `starvation telemetry` warns in logcat —
+growth mid-track marks any remaining starve/lock-miss source).
+
+### E.4 Regressions
+
+- DoP fallback still engages (`forceDop` mode + induced shim failure).
+- PCM paths unaffected. USB `UsbDsdNative` unaffected (shim backend only
+  active for DAP internal route).
+- `cargo check` host + `aarch64-linux-android` (or `--target` used by
+  build script), `flutter analyze`.
+- HiBy Music must still play after our track is released (no device leak).
+
+## F. Command sheet (adb, what actually works on the R4)
+
+```sh
+D="-s 764b099f"                     # HiBy R4 (USB transport)
+adb $D shell dumpsys media.audio_policy     # output profiles incl. DSD_NATIVE rates
+adb $D shell dumpsys media.audio_flinger    # per-thread HAL formats + track rows
+adb $D logcat -d | grep -i -e dsd -e audio_hw -e AudioFlinger
+# blocked for shell/app (SELinux): /proc/asound/*, /dev/snd/*
+# public native lib (pullable via shell):
+adb $D pull /system/lib64/libsmartaudioservice.so
+adb $D shell cat /system/etc/public.libraries.txt
+# drive Flick via intent (UI has no uiautomator semantics):
+adb $D shell am start -a android.intent.action.VIEW \
+  -d content://media/external/audio/media/<id> -t audio/dsd \
+  -n com.mossapps.flick/.MainActivity
+```
+
+## G. Phase 0 findings (recon complete)
+
+| Item | Value |
+|------|-------|
+| Device | HiBy R4, Android 12, kernel 4.14.190-perf aarch64, SELinux **Enforcing**, no root. `adb -s 764b099f`. |
+| `/proc/asound`, `/dev/snd` for apps | **DENIED** (`untrusted_app` vs `audio_device`, permissive=0). Direct ALSA impossible from any app incl. HiBy Music (uid 10077, also `untrusted_app`). |
+| HiBy Music native DSD mechanism | Framework offload AudioTrack: fmt `0x1A000001` `AUDIO_FORMAT_DSD_NATIVE` @ wire rate = DSD/32 (176 400 for DSD128), stereo, frame count 32 768, client flags **plain 0x0** (policy routes by format+rate), offload thread `AudioOut_18B5`, HAL flags 0x31, device WIRED_HEADPHONE (id 2156, tag h2w). Wire frame = 8 B = 2×32-bit subslots (proven by frames-written math). |
+| Policy DSD support | `compressed_offload` output: `AUDIO_FORMAT_DSD_NATIVE` @ 88 200 / 176 400 / 352 800 / 705 600 / 1 411 200 (= DSD64/128/256/512/1024), stereo. Also `dsd_compress_passthrough` output with `AUDIO_FORMAT_DSD` @ bit-rate domain (2 822 400/5 644 800). |
+| Java/framework | `framework.jar` has **no** DSD AudioFormat constants — Java cannot construct DSD tracks; HiBy's track creation is 100% native C++ via the shim. |
+| Shim | `/system/lib64/libsmartaudioservice.so` — public (in `public.libraries.txt`), 19.7 KB, dlopens `libaudioclient.so`, creates the real `AudioTrack`. Full ABI: §H. All `sas_*` exports are no-op stubs. |
+| HAL param probe | HiBy HAL exposes `get_dsd_modes` audio parameter (string in `libhibyservice.so`); R4 reports dsdMode bitmask (e.g. `00000004`), `hb_get_current_device_supported_dsd_modes dsdmods 5`. |
+| Flick today | Plays DoP on `androidManagedLowLatency` (managed path); `PcmAlsaBackend` direct-ALSA PCM bypass NOT actually usable on R4 (SELinux — earlier "works on R4" log showed managed path; presumably another device/firmware). |
+| Recon artifacts | `/tmp/opencode/`: `ap_dump.txt` (policy), `af_full.txt`/`af_live.txt` (flinger), `hiby_play_log.txt` (logcat), `apc.xml`, `libsmartaudioservice.so`, `libaudioclient.so`, `framework.jar`, `hiby_music.apk`, `hiby_src/` (jadx), `hiby_libs/`. |
+| Test media on device | MediaStore id 621 = Keane DSD64 `.dsf`; 644/646/647 = ClariS DSD256 `.dff`; 351 = Police DSD64; **1727 = ABBA Chiquitita DSD128 `.dsf` (duration 326 956 ms), primary test track**. |
+| First native stream (2026-08-30) | Flick debug build via shim: our client track fmt `1A000001` srate 176400 FrmCnt 32768 Active on offload thread — matches golden. Probe write 262 144 B → full. Track internals transfer=3 frameSize=1 flags 0x11. |
+| Route caveat | Speaker route (no HP plugged): HAL does not throttle — frames counter ~5.4 M fps (30×), ring drains at decoder speed, audio discarded. Wired-HP route paces exactly 176 400 fps (golden). Native DSD verification/A-B requires headphones plugged. |
+| Logging gotchas | FRB bundles android_logger 0.15 which clobbers global max_level after init (all Rust logs die ~0.6 s post-boot) → `assert_android_debug_logging()` re-assert at audio_init/play/queue_next. `dev_eprintln!` never reaches logcat — use `log::info!`. `logcat` rotates fast (Uac2Service polls ~10 lines/s) — capture evidence promptly. |
+
+## H. libsmartaudioservice.so ABI (reverse-engineered, device-verified)
+
+```
+create_track(p0=bit_rate: i32, p1: i32, p2=format_type: i32, p3: i32) -> *mut SasTrack
+  - fmtType 1..3 → PCM variants; fmtType 5..10 → DSD: format 0x1A000001,
+    wire_rate = (bit_rate + 31) >> 5 (i.e. /32, rounding), channel mask 3,
+    flags 0x10 COMPRESS_OFFLOAD, streamType MUSIC, frameCount 0 (→32768),
+    TRANSFER_DEFAULT(shared), 64-byte offload_info template.
+  - Returns 0x58-B vtable object; ctx (0x58 B) at obj[0x50];
+    ctx[+0x1c]=bit_rate, ctx[+0x24]=fmt_type, ctx[+0x28]=state,
+    mutex at ctx+0x2c, track sp<> at ctx[+0x8].
+  - ensure_track(ctx) runs BEFORE mutex/vtable init; NEGATIVE result →
+    free(obj+ctx) → returns NULL (a null create_track = real failure, not OOM).
+  - Property sys.audio.uac.bluetooth=="true" switches a BT format table (ignore).
+
+SasTrack vtable (slots hold PLT STUB addresses; first arg = obj):
+  obj[0x00] write(obj, buf: *u8, len: usize) -> i32   # → AudioTrack::write(…, blocking=true);
+                                                       # returns len UNCONDITIONALLY when a track
+                                                       # exists (real result discarded!); 0 only
+                                                       # when ensure_track failed
+  obj[0x18] start(obj)                                # AudioTrack::start
+  obj[0x20] flush(obj)                                # AudioTrack::flush
+  obj[0x10] teardown(obj)                             # stop + release tracks (obj reusable)
+  obj[0x08] soft-stop(obj)                            # stop, KEEPS track — do not confuse with write!
+  obj[0x28] stopped(obj) -> bool                      # 1 while ALIVE: track ? !AudioTrack::stopped()
+                                                       #                : (ctx state != 4)  [0x2a10]
+  obj[0x38] get_rate(obj) -> i32                      # returns bit_rate
+  obj[0x40] get_channels(obj) -> i32                  # returns create_track arg p1
+  obj[0x30] latency(obj) -> i32
+  obj[0x50] ctx pointer
+  release_track(obj)                                  # frees obj + ctx
+
+Flick call recipe (DSD128; stock-exact args per logcat):
+  let t = create_track(5_644_800, 2, 6, 1);           // null → fail
+  start(t); write(t, packed_wire_buf, 262_144);        // one HAL period per write
+  flush(t) on seek; teardown(t); release_track(t);
+
+Framework internals that matter (R4 libaudioclient.so, HiBy-patched):
+  - write() accepts mTransfer ∈ {3 SHARED, 5 SYNC_NOTIF} (vanilla: 4/5) —
+    set() maps TRANSFER_DEFAULT+no sharedBuffer+no cbf → SHARED (vanilla: SYNC).
+  - set() mFrameSize for non-proportional formats (DSD) = 1 → any write size
+    works; pacing must come from blocking obtainBuffer.
+  - Verified live: track transfer=3 frameSize=1 status=0 flags 0x11.
+```
+
+Packing (RE + audioserver arithmetic + on-device calibration, 2026-08-30):
+the DSD output stream runs at `bit_rate/32` Hz with channel mask 0x3 and
+4 B per stereo frame (705 600 B/s for DSD128). On-ear calibration picked
+**U8 byte-interleaved LRLR, MSB-first** (clean; the 4 B/frame are four
+interleaved bytes, not two 16-bit subslots — the earlier U16 reading
+hissed). U32 LLLL|RRRR and U16 LL|RR remain selectable for other DAPs.
+Stock's engine write path (`libhibyservice.so 0x4450d8`) is a verbatim
+memcpy — no byte transform, zero `rbit` in the whole lib — so wire bytes =
+decoder output. Bit order in subslot + slot endianness covered by the 4
+packer variants (default BE/MSB-first). DSD silence byte = **0x69** (what
+stock's drain loop memsets before stop; SACD convention) — also used for
+pause/gap/underrun fills via `AudioCallbackData::fill_silence`.
+
+## I. History — why the ALSA phases died (superseded)
+
+Original plan: probe `/dev/snd/pcmC*D*p` with HW_REFINE DSD sweeps
+(`FMT_DSD_U8=56/U16_LE=57/U32_LE=58`), per-DAP hint table, negotiated open.
+Killed by recon: SELinux `untrusted_app` cannot even *search* `/dev/snd` on
+this ROM (`avc: denied { read search } tcontext=u:object_r:audio_device:s0
+permissive=0`), so no ioctl is reachable — and stock HiBy Music (also
+`untrusted_app`) proves the vendor route is the framework, not ALSA.
+`dsd_alsa_direct.rs` stays for environments where it does work (rooted
+devices, desktops).

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1015,7 +1015,7 @@ class _EmbeddedMiniPlayerState extends ConsumerState<_EmbeddedMiniPlayer> {
         ref.read(playerProvider.notifier).next();
       } else {
         _songChangeDirection = 1;
-        ref.read(playerProvider.notifier).previous();
+        ref.read(playerProvider.notifier).previous(allowRestart: false);
       }
     } else {
       setState(() {

--- a/lib/data/repositories/song_repository.dart
+++ b/lib/data/repositories/song_repository.dart
@@ -48,7 +48,7 @@ class SongRepository {
         .findAll();
   }
 
-  /// Search songs by title, artist, or album.
+  /// Search songs by title, artist, album, albumArtist or genre.
   Future<List<Song>> searchSongs(String query) async {
     final lowerQuery = query.toLowerCase();
     final entities = await _isar.songEntitys
@@ -58,9 +58,29 @@ class SongRepository {
         .artistContains(lowerQuery, caseSensitive: false)
         .or()
         .albumContains(lowerQuery, caseSensitive: false)
+        .or()
+        .albumArtistContains(lowerQuery, caseSensitive: false)
+        .or()
+        .genreContains(lowerQuery, caseSensitive: false)
         .sortByTitle()
         .findAll();
-    return entities.map(_entityToSong).toList();
+    var results = entities.map(_entityToSong).toList();
+    // Year is numeric – include songs where the year string contains the query.
+    if (lowerQuery.isNotEmpty && RegExp(r'\d').hasMatch(lowerQuery)) {
+      final all = await getAllSongs();
+      final yearMatches = all.where((s) {
+        final y = s.year;
+        if (y == null) return false;
+        return y.toString().contains(lowerQuery);
+      }).toList();
+      final seen = results.map((s) => s.id).toSet();
+      for (final s in yearMatches) {
+        if (!seen.contains(s.id)) results.add(s);
+      }
+      results.sort((a, b) => a.title.compareTo(b.title));
+    }
+    // Folder name matches are handled via GlobalSearchResults; kept minimal here.
+    return results;
   }
 
   /// Get song count.

--- a/lib/features/player/widgets/bit_perfect_indicator.dart
+++ b/lib/features/player/widgets/bit_perfect_indicator.dart
@@ -576,13 +576,30 @@ class _AudioInfoBottomSheetState extends ConsumerState<_AudioInfoBottomSheet> {
         d?.requestedOutputSampleRate ??
         widget.deviceStatus?.currentFormat?.sampleRate;
     if (outRate != null) {
-      final sourceRate = widget.song.sampleRate;
-      final matches = sourceRate != null && sourceRate == outRate;
+      // DSD transports report a divided rate (native ÷8, DoP ÷16, wire ÷32).
+      // Show the DSD bit rate like the DAP does; any valid domain matches.
+      int displayRate = outRate;
+      var matches = false;
+      final dsdBitRate = widget.song.isDsd ? widget.song.sampleRate : null;
+      if (dsdBitRate != null) {
+        if (outRate == dsdBitRate) {
+          displayRate = dsdBitRate;
+          matches = true;
+        } else if (outRate * 8 == dsdBitRate ||
+            outRate * 16 == dsdBitRate ||
+            outRate * 32 == dsdBitRate) {
+          displayRate = dsdBitRate;
+          matches = true;
+        }
+      } else {
+        final sourceRate = widget.song.sampleRate;
+        matches = sourceRate != null && sourceRate == outRate;
+      }
       rows.add(
         _buildRow(
           context,
           label: 'Output rate',
-          value: _formatHz(outRate),
+          value: _formatHz(displayRate),
           trailing: matches
               ? Icon(Icons.check_circle_rounded, size: 14, color: Colors.green.shade400)
               : Icon(Icons.warning_amber_rounded, size: 14, color: Colors.amber.shade400),

--- a/lib/features/player/widgets/song_stage.dart
+++ b/lib/features/player/widgets/song_stage.dart
@@ -23,6 +23,9 @@ import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 /// The sliding portion of the player: album art + title/artist/album +
 /// file-info row + waveform. Background, top chrome and [PlayerControls]
 /// stay pinned — only this stage translates during a swipe.
+///
+/// The file-info row keeps its layout slot even when hidden; the row is
+/// then drawn pinned by the parent screen ([fileInfoRowVisible]).
 class SongStage extends StatelessWidget {
   static const double _shortHeightThreshold = 620.0;
 
@@ -41,6 +44,9 @@ class SongStage extends StatelessWidget {
   final void Function(Song song) onNavigateToAlbumDetail;
   final Widget Function(Song song, bool lyricsMode, PlayerScreenMode mode)
   buildFileInfoRow;
+
+  /// Hides the row but keeps its slot (pinned row renders on top of it).
+  final bool fileInfoRowVisible;
   final String visualizerAnimationStyle;
   final String visualizerFrequencyMode;
   final String visualizerMovementMode;
@@ -80,6 +86,7 @@ class SongStage extends StatelessWidget {
     required this.onNavigateToArtistDetail,
     required this.onNavigateToAlbumDetail,
     required this.buildFileInfoRow,
+    this.fileInfoRowVisible = true,
     this.visualizerAnimationStyle = 'bars',
     this.visualizerFrequencyMode = 'full',
     this.visualizerMovementMode = 'bouncy',
@@ -127,19 +134,14 @@ class SongStage extends StatelessWidget {
         );
       },
       transitionBuilder: (Widget child, Animation<double> animation) {
-        final isFullView =
-            child.key == const ValueKey('immersive-full-view');
+        final isFullView = child.key == const ValueKey('immersive-full-view');
         final slideOffset = isFullView
             ? const Offset(0, 0.12)
             : const Offset(0, 0.03);
         return SlideTransition(
-          position: Tween<Offset>(begin: slideOffset, end: Offset.zero)
-              .animate(
-                CurvedAnimation(
-                  parent: animation,
-                  curve: Curves.easeOutCubic,
-                ),
-              ),
+          position: Tween<Offset>(begin: slideOffset, end: Offset.zero).animate(
+            CurvedAnimation(parent: animation, curve: Curves.easeOutCubic),
+          ),
           child: FadeTransition(opacity: animation, child: child),
         );
       },
@@ -284,18 +286,24 @@ class SongStage extends StatelessWidget {
                                 SizedBox(
                                   height: context.responsive(10.0, 12.0, 14.0),
                                 ),
-                                Padding(
-                                  padding: EdgeInsets.symmetric(
-                                    horizontal: context.responsive(
-                                      12.0,
-                                      16.0,
-                                      20.0,
+                                Visibility(
+                                  visible: fileInfoRowVisible,
+                                  maintainSize: true,
+                                  maintainAnimation: true,
+                                  maintainState: true,
+                                  child: Padding(
+                                    padding: EdgeInsets.symmetric(
+                                      horizontal: context.responsive(
+                                        12.0,
+                                        16.0,
+                                        20.0,
+                                      ),
                                     ),
-                                  ),
-                                  child: buildFileInfoRow(
-                                    song,
-                                    lyricsMode,
-                                    playerScreenMode,
+                                    child: buildFileInfoRow(
+                                      song,
+                                      lyricsMode,
+                                      playerScreenMode,
+                                    ),
                                   ),
                                 ),
                               ],
@@ -333,9 +341,7 @@ class SongStage extends StatelessWidget {
         final isLyricsChild =
             child.key == const ValueKey('immersive-lyrics-layout');
         final offsetAnimation = Tween<Offset>(
-          begin: isLyricsChild
-              ? const Offset(0, -0.04)
-              : const Offset(0, 0.05),
+          begin: isLyricsChild ? const Offset(0, -0.04) : const Offset(0, 0.05),
           end: Offset.zero,
         ).animate(animation);
         return FadeTransition(
@@ -371,7 +377,9 @@ class SongStage extends StatelessWidget {
           child: Row(
             children: [
               ClipRRect(
-                borderRadius: BorderRadius.circular(18 * immersiveFullViewScale),
+                borderRadius: BorderRadius.circular(
+                  18 * immersiveFullViewScale,
+                ),
                 child: SizedBox(
                   width: artworkSize,
                   height: artworkSize,
@@ -573,17 +581,18 @@ class SongStage extends StatelessWidget {
                   transitionBuilder: (child, animation) {
                     final isLyrics =
                         child.key == const ValueKey('artwork-lyrics');
-                    final slide = Tween<Offset>(
-                      begin: isLyrics
-                          ? const Offset(0, -0.06)
-                          : const Offset(0, 0.06),
-                      end: Offset.zero,
-                    ).animate(
-                      CurvedAnimation(
-                        parent: animation,
-                        curve: Curves.easeOutCubic,
-                      ),
-                    );
+                    final slide =
+                        Tween<Offset>(
+                          begin: isLyrics
+                              ? const Offset(0, -0.06)
+                              : const Offset(0, 0.06),
+                          end: Offset.zero,
+                        ).animate(
+                          CurvedAnimation(
+                            parent: animation,
+                            curve: Curves.easeOutCubic,
+                          ),
+                        );
                     return FadeTransition(
                       opacity: CurvedAnimation(
                         parent: animation,
@@ -678,7 +687,13 @@ class SongStage extends StatelessWidget {
                 ),
               ),
               if (artworkCardShowFileInfo)
-                buildFileInfoRow(song, lyricsMode, playerScreenMode),
+                Visibility(
+                  visible: fileInfoRowVisible,
+                  maintainSize: true,
+                  maintainAnimation: true,
+                  maintainState: true,
+                  child: buildFileInfoRow(song, lyricsMode, playerScreenMode),
+                ),
               if (showWaveform) ...[
                 if (artworkCardShowFileInfo) SizedBox(height: playbackSpacing),
                 _buildWaveformOnly(context),
@@ -704,11 +719,11 @@ class SongStage extends StatelessWidget {
         artworkCardTextScale;
     final artistSize =
         (veryCompact
-                ? context.responsive(13.0, 14.0, 15.0)
-                : compact
-                ? context.responsive(14.0, 15.0, 16.0)
-                : context.responsive(15.0, 16.0, 17.0)) *
-            artworkCardTextScale;
+            ? context.responsive(13.0, 14.0, 15.0)
+            : compact
+            ? context.responsive(14.0, 15.0, 16.0)
+            : context.responsive(15.0, 16.0, 17.0)) *
+        artworkCardTextScale;
     final titleToArtistSpacing = veryCompact
         ? 6.0
         : context.responsive(8.0, 10.0, 12.0);
@@ -725,9 +740,9 @@ class SongStage extends StatelessWidget {
         : context.responsive(6.0, 7.0, 8.0);
     final albumFontSize =
         (veryCompact
-                ? context.responsive(10.0, 11.0, 12.0)
-                : context.responsive(11.0, 12.0, 13.0)) *
-            artworkCardTextScale;
+            ? context.responsive(10.0, 11.0, 12.0)
+            : context.responsive(11.0, 12.0, 13.0)) *
+        artworkCardTextScale;
 
     final diagnostics = ProviderScope.containerOf(
       context,
@@ -873,7 +888,8 @@ class SongStage extends StatelessWidget {
   // ---------------------------------------------------------------------------
 
   Widget _buildWaveformOnly(BuildContext context) {
-    final immersivePlaybackPadding = playerScreenMode == PlayerScreenMode.immersive
+    final immersivePlaybackPadding =
+        playerScreenMode == PlayerScreenMode.immersive
         ? context.responsive(18.0, 24.0, 30.0)
         : 0.0;
 

--- a/lib/features/settings/screens/uac2_preferences_screen.dart
+++ b/lib/features/settings/screens/uac2_preferences_screen.dart
@@ -264,7 +264,9 @@ class _Uac2PreferencesScreenState extends ConsumerState<Uac2PreferencesScreen> {
                       ? 'Disabled in Bit-perfect (USB DAC) mode (exact rate required)'
                       : 'Audio Format is disabled'
                   : format != null
-                  ? '${format.sampleRate ~/ 1000}kHz / ${format.bitDepth}bit / ${format.channels}ch'
+                  ? format.isDsdStream
+                        ? '${format.displayRateLabel} / ${format.channels}ch'
+                        : '${format.sampleRate ~/ 1000}kHz / ${format.bitDepth}bit / ${format.channels}ch'
                   : 'Not set',
               onTap: formatBlocked
                   ? () => isBitPerfectEnabled
@@ -1439,6 +1441,28 @@ ref.invalidate(uac2ExclusiveDacModeProvider);
             loading: () => _buildLoadingTile(context),
             error: (_, _) => _buildErrorTile(context),
           ),
+          _buildDivider(),
+          ValueListenableBuilder<DsdWireVariant>(
+            valueListenable: Uac2PreferencesService.dsdWireVariantNotifier,
+            builder: (context, variant, _) => _buildNavigationTile(
+              context,
+              icon: LucideIcons.binary,
+              title: 'DAP Native Bit Order',
+              subtitle: _dsdWireVariantSubtitle(variant),
+              onTap: () => _showDsdWireVariantDialog(context, service, variant),
+            ),
+          ),
+          _buildDivider(),
+          ValueListenableBuilder<DsdWireGrouping>(
+            valueListenable: Uac2PreferencesService.dsdWireGroupingNotifier,
+            builder: (context, grouping, _) => _buildNavigationTile(
+              context,
+              icon: LucideIcons.columns2,
+              title: 'DAP Native Byte Grouping',
+              subtitle: _dsdWireGroupingSubtitle(grouping),
+              onTap: () => _showDsdWireGroupingDialog(context, service, grouping),
+            ),
+          ),
         ],
       ),
     );
@@ -1603,6 +1627,178 @@ ref.invalidate(uac2ExclusiveDacModeProvider);
                 if (dialogContext.mounted) Navigator.of(dialogContext).pop();
               },
             ),
+          ],
+        ),
+        actions: [
+          FlickDialogButton(
+            label: 'Cancel',
+            onPressed: () => Navigator.of(dialogContext).pop(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _dsdWireVariantSubtitle(DsdWireVariant variant) {
+    switch (variant) {
+      case DsdWireVariant.auto:
+        return 'Auto — BE-MSB default; only change if native DSD hisses';
+      case DsdWireVariant.beMsb:
+        return 'BE-MSB — big-endian subslot, MSB first (default)';
+      case DsdWireVariant.leMsb:
+        return 'LE-MSB — little-endian subslot, MSB first';
+      case DsdWireVariant.beLsb:
+        return 'BE-LSB — big-endian subslot, LSB first';
+      case DsdWireVariant.leLsb:
+        return 'LE-LSB — little-endian subslot, LSB first';
+    }
+  }
+
+  String _dsdWireGroupingSubtitle(DsdWireGrouping grouping) {
+    switch (grouping) {
+      case DsdWireGrouping.auto:
+        return 'Auto — U8 byte-interleaved (recommended)';
+      case DsdWireGrouping.u32:
+        return 'U32 — 4-byte subslots, LLLL|RRRR (legacy)';
+      case DsdWireGrouping.u16:
+        return 'U16 — 2-byte subslots, LL|RR';
+      case DsdWireGrouping.u8:
+        return 'U8 — byte-interleaved LRLR';
+    }
+  }
+
+  void _showDsdWireGroupingDialog(
+    BuildContext context,
+    Uac2PreferencesService service,
+    DsdWireGrouping current,
+  ) {
+    showFlickDialog<void>(
+      context: context,
+      barrierLabel: 'DAP Native Byte Grouping',
+      builder: (dialogContext) => FlickDialog(
+        title: 'DAP Native Byte Grouping',
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final (grouping, title, subtitle) in [
+              (
+                DsdWireGrouping.auto,
+                'Auto',
+                'U8 — byte-interleaved, recommended default'
+              ),
+              (
+                DsdWireGrouping.u32,
+                'U32',
+                '32-bit subslots: LLLL|RRRR per frame (legacy)'
+              ),
+              (
+                DsdWireGrouping.u16,
+                'U16',
+                '16-bit subslots: LL|RR per frame'
+              ),
+              (
+                DsdWireGrouping.u8,
+                'U8',
+                'Byte-interleaved: LRLR stream'
+              ),
+            ]) ...[
+              _buildDsdOptionTile(
+                dialogContext,
+                title: title,
+                subtitle: subtitle,
+                selected: current == grouping,
+                onTap: () async {
+                  await service.setDsdWireGrouping(grouping);
+                  // Applies to the very next wire write — live A/B while a
+                  // DAP native-DSD track is playing.
+                  rust_audio.audioSetSasWireGrouping(
+                    grouping: switch (grouping) {
+                      DsdWireGrouping.auto => 2,
+                      DsdWireGrouping.u32 => 0,
+                      DsdWireGrouping.u16 => 1,
+                      DsdWireGrouping.u8 => 2,
+                    },
+                  );
+                  if (dialogContext.mounted) Navigator.of(dialogContext).pop();
+                },
+              ),
+              const SizedBox(height: AppConstants.spacingSm),
+            ],
+          ],
+        ),
+        actions: [
+          FlickDialogButton(
+            label: 'Cancel',
+            onPressed: () => Navigator.of(dialogContext).pop(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showDsdWireVariantDialog(
+    BuildContext context,
+    Uac2PreferencesService service,
+    DsdWireVariant current,
+  ) {
+    showFlickDialog<void>(
+      context: context,
+      barrierLabel: 'DAP Native Bit Order',
+      builder: (dialogContext) => FlickDialog(
+        title: 'DAP Native Bit Order',
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final (variant, title, subtitle) in [
+              (
+                DsdWireVariant.auto,
+                'Auto',
+                'BE-MSB packing — the default wire convention'
+              ),
+              (
+                DsdWireVariant.beMsb,
+                'BE-MSB',
+                'Big-endian 32-bit subslot, MSB-first bits'
+              ),
+              (
+                DsdWireVariant.leMsb,
+                'LE-MSB',
+                'Little-endian subslot, MSB-first bits'
+              ),
+              (
+                DsdWireVariant.beLsb,
+                'BE-LSB',
+                'Big-endian subslot, LSB-first (bit-reversed) bits'
+              ),
+              (
+                DsdWireVariant.leLsb,
+                'LE-LSB',
+                'Little-endian subslot, LSB-first bits'
+              ),
+            ]) ...[
+              _buildDsdOptionTile(
+                dialogContext,
+                title: title,
+                subtitle: subtitle,
+                selected: current == variant,
+                onTap: () async {
+                  await service.setDsdWireVariant(variant);
+                  // Applies to the very next wire write — live A/B while a
+                  // DAP native-DSD track is playing.
+                  rust_audio.audioSetSasWireVariant(
+                    variant: switch (variant) {
+                      DsdWireVariant.auto => 0,
+                      DsdWireVariant.beMsb => 0,
+                      DsdWireVariant.leMsb => 1,
+                      DsdWireVariant.beLsb => 2,
+                      DsdWireVariant.leLsb => 3,
+                    },
+                  );
+                  if (dialogContext.mounted) Navigator.of(dialogContext).pop();
+                },
+              ),
+              const SizedBox(height: AppConstants.spacingSm),
+            ],
           ],
         ),
         actions: [

--- a/lib/features/settings/screens/uac2_settings_screen.dart
+++ b/lib/features/settings/screens/uac2_settings_screen.dart
@@ -638,15 +638,15 @@ class _Uac2SettingsScreenState extends ConsumerState<Uac2SettingsScreen> {
             _buildDivider(),
             _buildInfoRow(
               context,
-              'Track Sample Rate',
-              '${status.currentFormat!.sampleRate ~/ 1000}kHz',
+              status.currentFormat!.isDsdStream ? 'Track DSD Rate' : 'Track Sample Rate',
+              status.currentFormat!.displayRateLabel,
               Icons.graphic_eq,
             ),
             _buildDivider(),
             _buildInfoRow(
               context,
               'Track Bit Depth',
-              '${status.currentFormat!.bitDepth}bit',
+              status.currentFormat!.bitDepthLabel,
               LucideIcons.layers,
             ),
             _buildDivider(),

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -369,8 +369,13 @@ class PlayerNotifier extends Notifier<PlayerState> {
   }
 
   /// Skip to previous song.
-  Future<void> previous() async {
-    await _service.previous();
+  /// [allowRestart] true = button behavior (restart if >3s), false = swipe/slide (always previous track)
+  Future<void> previous({bool allowRestart = true}) async {
+    await _service.previous(allowRestart: allowRestart);
+  }
+
+  Future<void> previousBySwipe() async {
+    await _service.previousBySwipe();
   }
 
   /// Toggle shuffle mode.

--- a/lib/services/android_audio_processing_service.dart
+++ b/lib/services/android_audio_processing_service.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flick/providers/equalizer_provider.dart';
 
@@ -40,6 +41,10 @@ class AndroidJustAudioProcessingService {
     );
 
     if (request.requiresAudioSession && audioSessionId == null) {
+      debugPrint(
+        '[AndroidAudioProcessing] skipping apply: audio effects requested but '
+        'audio session id is not available yet',
+      );
       return;
     }
 

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -1379,7 +1379,8 @@ class PlayerService {
   AudioEngineType get currentEngineType =>
       _sessionManager.initializedMode ?? _sessionManager.selectedMode;
   bool get isBitPerfectModeEnabled =>
-      _uac2Service.isBitPerfectEnabledSync ||
+      (currentEngineType == AudioEngineType.usbDacExperimental &&
+          _uac2Service.isBitPerfectEnabledSync) ||
       (currentEngineType == AudioEngineType.dapInternalHighRes &&
           _uac2Service.isDapBitPerfectEnabledSync);
   bool get isBitPerfectProcessingLocked =>

--- a/lib/services/rust_audio_service.dart
+++ b/lib/services/rust_audio_service.dart
@@ -89,6 +89,23 @@ class RustAudioService {
       } catch (e) {
         devLog('Failed to restore Android audio API preference: $e');
       }
+      // Restore DSD output mode + transport overrides before the first play;
+      // this also loads the pref notifiers (else a user-set mode is ignored).
+      try {
+        await Uac2PreferencesService().getDsdOutputMode();
+        await Uac2PreferencesService().getDsdByteOrderOverride();
+        await Uac2PreferencesService().getDsdSubslotOverride();
+        await Uac2PreferencesService().getDsdWireVariant();
+        await Uac2PreferencesService().getDsdWireGrouping();
+        _syncDsdOutputMode();
+        _syncDsdTransportOverrides();
+        devLog(
+          'Restored DSD output mode: '
+          '${Uac2PreferencesService.dsdOutputModeSync.name}',
+        );
+      } catch (e) {
+        devLog('Failed to restore DSD output mode: $e');
+      }
       _initialized = true;
       devLog('Rust audio engine manager initialized');
 
@@ -320,12 +337,13 @@ class RustAudioService {
       DsdOutputMode.forceDop => 1,
       DsdOutputMode.native => 2,
     };
+    // frb(sync): executes synchronously, so the store is done before the
+    // audioPlay call issued right after this.
     rust_audio.audioSetDsdOutputMode(mode: rustMode);
   }
 
-  /// Push native-DSD transport field-tuning overrides (byte order, subslot)
-  /// to the engine. These only affect the USB direct native DSD path and
-  /// default to auto (defer to device quirk).
+  /// Push native-DSD tuning overrides to the engine. Byte order + subslot
+  /// affect the USB direct path; wire variant + grouping the DAP shim path.
   void _syncDsdTransportOverrides() {
     final byteOrder = Uac2PreferencesService.dsdByteOrderOverrideSync;
     rust_audio.audioSetDsdBigEndianOverride(
@@ -337,6 +355,24 @@ class RustAudioService {
     );
     rust_audio.audioSetDsdSubslotOverride(
       value: Uac2PreferencesService.dsdSubslotOverrideSync,
+    );
+    rust_audio.audioSetSasWireVariant(
+      variant: switch (Uac2PreferencesService.dsdWireVariantSync) {
+        DsdWireVariant.auto => 0,
+        DsdWireVariant.beMsb => 0,
+        DsdWireVariant.leMsb => 1,
+        DsdWireVariant.beLsb => 2,
+        DsdWireVariant.leLsb => 3,
+      },
+    );
+    // Auto = U8: on-device calibration picked plain byte interleaving (LRLR).
+    rust_audio.audioSetSasWireGrouping(
+      grouping: switch (Uac2PreferencesService.dsdWireGroupingSync) {
+        DsdWireGrouping.auto => 2,
+        DsdWireGrouping.u32 => 0,
+        DsdWireGrouping.u16 => 1,
+        DsdWireGrouping.u8 => 2,
+      },
     );
   }
 

--- a/lib/services/uac2_preferences_service.dart
+++ b/lib/services/uac2_preferences_service.dart
@@ -14,12 +14,22 @@ enum DsdOutputMode { auto, forcePcm, forceDop, native }
 /// Per-device field-tuning override for native-DSD wire byte order (DSD_U32 packing).
 enum DsdByteOrderOverride { auto, littleEndian, bigEndian }
 
+/// Wire-packing variant for the DAP-internal native-DSD shim transport
+/// (bit order + subslot endianness inside each subslot).
+enum DsdWireVariant { auto, beMsb, leMsb, beLsb, leLsb }
+
+/// Wire byte grouping (subslot width) for the DAP-internal native-DSD shim
+/// transport: how many consecutive DSD bytes per channel form one subslot.
+enum DsdWireGrouping { auto, u32, u16, u8 }
+
 class Uac2PreferencesService {
   static final ValueNotifier<bool> developerModeNotifier = ValueNotifier(false);
   static final ValueNotifier<bool> killIsochronousUsbOnQuitNotifier = ValueNotifier(true);
   static final ValueNotifier<DsdOutputMode> dsdOutputModeNotifier = ValueNotifier(DsdOutputMode.auto);
   static final ValueNotifier<DsdByteOrderOverride> dsdByteOrderOverrideNotifier = ValueNotifier(DsdByteOrderOverride.auto);
   static final ValueNotifier<int?> dsdSubslotOverrideNotifier = ValueNotifier(null);
+  static final ValueNotifier<DsdWireVariant> dsdWireVariantNotifier = ValueNotifier(DsdWireVariant.auto);
+  static final ValueNotifier<DsdWireGrouping> dsdWireGroupingNotifier = ValueNotifier(DsdWireGrouping.auto);
   static const _keySelectedDevice = 'uac2_selected_device';
   static const _keyPreferredFormat = 'uac2_preferred_format';
   static const _keyFormatPreference = 'uac2_format_preference';
@@ -40,12 +50,16 @@ class Uac2PreferencesService {
   static const _keyAutoSwitchDsdForVolume = 'auto_switch_dsd_for_volume';
   static const _keyDsdByteOrderOverride = 'dsd_byte_order_override';
   static const _keyDsdSubslotOverride = 'dsd_subslot_override';
+  static const _keyDsdWireVariant = 'dsd_wire_variant';
+  static const _keyDsdWireGrouping = 'dsd_wire_grouping';
 
   static bool get isDeveloperModeEnabledSync => developerModeNotifier.value;
   static bool get isKillIsochronousUsbOnQuitSync => killIsochronousUsbOnQuitNotifier.value;
   static DsdOutputMode get dsdOutputModeSync => dsdOutputModeNotifier.value;
   static DsdByteOrderOverride get dsdByteOrderOverrideSync => dsdByteOrderOverrideNotifier.value;
   static int? get dsdSubslotOverrideSync => dsdSubslotOverrideNotifier.value;
+  static DsdWireVariant get dsdWireVariantSync => dsdWireVariantNotifier.value;
+  static DsdWireGrouping get dsdWireGroupingSync => dsdWireGroupingNotifier.value;
   static final ValueNotifier<bool> autoSwitchDsdForVolumeNotifier = ValueNotifier(false);
   static bool get autoSwitchDsdForVolumeSync => autoSwitchDsdForVolumeNotifier.value;
   static final ValueNotifier<bool> tuning432HzNotifier = ValueNotifier(false);
@@ -563,6 +577,66 @@ class Uac2PreferencesService {
     }
   }
 
+  /// Set the DAP native-DSD wire-packing variant (bit order + subslot
+  /// endianness). Wrong variant = hiss/static on DAPs; calibrate per device.
+  Future<void> setDsdWireVariant(DsdWireVariant value) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keyDsdWireVariant, value.name);
+      dsdWireVariantNotifier.value = value;
+    } catch (e) {
+      devLog('Failed to save DSD wire variant: $e');
+    }
+  }
+
+  Future<DsdWireVariant> getDsdWireVariant() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final value = prefs.getString(_keyDsdWireVariant);
+      final variant = value == null
+          ? DsdWireVariant.auto
+          : DsdWireVariant.values.firstWhere(
+              (e) => e.name == value,
+              orElse: () => DsdWireVariant.auto,
+            );
+      dsdWireVariantNotifier.value = variant;
+      return variant;
+    } catch (e) {
+      devLog('Failed to load DSD wire variant: $e');
+      return DsdWireVariant.auto;
+    }
+  }
+
+  /// Set the DAP native-DSD wire grouping (subslot width). Wrong grouping =
+  /// hiss regardless of bit order; calibrate per device.
+  Future<void> setDsdWireGrouping(DsdWireGrouping value) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_keyDsdWireGrouping, value.name);
+      dsdWireGroupingNotifier.value = value;
+    } catch (e) {
+      devLog('Failed to save DSD wire grouping: $e');
+    }
+  }
+
+  Future<DsdWireGrouping> getDsdWireGrouping() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final value = prefs.getString(_keyDsdWireGrouping);
+      final grouping = value == null
+          ? DsdWireGrouping.auto
+          : DsdWireGrouping.values.firstWhere(
+              (e) => e.name == value,
+              orElse: () => DsdWireGrouping.auto,
+            );
+      dsdWireGroupingNotifier.value = grouping;
+      return grouping;
+    } catch (e) {
+      devLog('Failed to load DSD wire grouping: $e');
+      return DsdWireGrouping.auto;
+    }
+  }
+
   /// Force a native-DSD subslot size (1=U8, 2=U16, 4=U32). Pass null for auto.
   Future<void> setDsdSubslotOverride(int? value) async {
     try {
@@ -634,9 +708,13 @@ await prefs.remove(_keyAudioEnginePreference);
     await prefs.remove(_keyBtHiResDirect);
     await prefs.remove(_keyDsdByteOrderOverride);
     await prefs.remove(_keyDsdSubslotOverride);
+    await prefs.remove(_keyDsdWireVariant);
+    await prefs.remove(_keyDsdWireGrouping);
       dsdOutputModeNotifier.value = DsdOutputMode.auto;
       dsdByteOrderOverrideNotifier.value = DsdByteOrderOverride.auto;
       dsdSubslotOverrideNotifier.value = null;
+      dsdWireVariantNotifier.value = DsdWireVariant.auto;
+      dsdWireGroupingNotifier.value = DsdWireGrouping.auto;
       developerModeNotifier.value = false;
       killIsochronousUsbOnQuitNotifier.value = true;
       tuning432HzNotifier.value = false;

--- a/lib/services/uac2_service.dart
+++ b/lib/services/uac2_service.dart
@@ -52,6 +52,51 @@ class Uac2AudioFormat {
       isNativeDsd: (json['isNativeDsd'] as bool?) ?? false,
     );
   }
+
+  /// True when this format represents a DSD stream in a byte/carrier-rate
+  /// domain (native: sampleRate is the byte rate; DoP: the PCM carrier).
+  bool get isDsdStream => isNativeDsd || isDop;
+
+  /// The 1-bit DSD bit rate in Hz. Native DSD stores the byte rate
+  /// (bit rate / 8); DoP stores the PCM carrier rate (bit rate / 16).
+  int get dsdBitRateHz => isNativeDsd
+      ? sampleRate * 8
+      : isDop
+      ? sampleRate * 16
+      : sampleRate;
+
+  /// SACD-style rate label (mirrors Song.dsdRateLabel thresholds).
+  String get dsdRateLabel {
+    final bitRate = dsdBitRateHz;
+    if (bitRate >= 22579200) return 'DSD512';
+    if (bitRate >= 11289600) return 'DSD256';
+    if (bitRate >= 5644800) return 'DSD128';
+    if (bitRate >= 2822400) return 'DSD64';
+    return 'DSD';
+  }
+
+  /// Human label for the format's rate: DSD streams show the 1-bit domain
+  /// (e.g. '5.6 MHz · DSD128'); PCM falls back to kHz.
+  String get displayRateLabel {
+    if (isDsdStream) {
+      return '${_dsdMHzLabel()} · $dsdRateLabel';
+    }
+    return '${sampleRate ~/ 1000}kHz';
+  }
+
+  /// Compact chip label: 'DSD128 5.6MHz' for DSD, '705kHz' for PCM.
+  String get compactRateLabel =>
+      isDsdStream ? '$dsdRateLabel $_dsdMHzLabel()' : '${sampleRate ~/ 1000}kHz';
+
+  String _dsdMHzLabel() {
+    final mhz = dsdBitRateHz / 1000000.0;
+    if (mhz >= 1.0) return '${mhz.toStringAsFixed(1)}MHz';
+    return '${(dsdBitRateHz / 1000.0).toStringAsFixed(0)}kHz';
+  }
+
+  /// Human label for the depth: DSD is 1-bit; PCM shows its depth.
+  String get bitDepthLabel =>
+      isDsdStream ? '1-bit (DSD)' : '${bitDepth}bit';
 }
 
 class Uac2DeviceCapabilities {

--- a/lib/src/rust/api/audio_api.dart
+++ b/lib/src/rust/api/audio_api.dart
@@ -12,7 +12,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'audio_api.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `ensure_audio_engine_excluded`, `ensure_audio_engine`, `prepare_decoder_source`, `read_audio_engine`, `resolve_dsd_engine_sample_rate`, `resolve_requested_output_sample_rate`, `resolve_track_playback_output_sample_rate`, `verify_dop_passthrough`, `verify_dsd_engine_rate`, `with_audio_engine`
+// These functions are ignored because they are not marked as `pub`: `ensure_audio_engine_excluded`, `ensure_audio_engine`, `prepare_decoder_source`, `read_audio_engine`, `record_dsd_native_failure`, `resolve_dsd_engine_sample_rate`, `resolve_requested_output_sample_rate`, `resolve_track_playback_output_sample_rate`, `verify_dop_passthrough`, `verify_dsd_engine_rate`, `with_audio_engine`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`
 
 Future<DsdOutputMode> currentDsdOutputMode() =>
@@ -34,6 +34,12 @@ Future<DsdOutputMode> effectiveDsdOutputModeForRate({
 
 Future<void> setDsdTrackRate({required int rate}) =>
     RustLib.instance.api.crateApiAudioApiSetDsdTrackRate(rate: rate);
+
+Future<String?> lastDsdNativeFailure() =>
+    RustLib.instance.api.crateApiAudioApiLastDsdNativeFailure();
+
+Future<void> clearDsdNativeFailure() =>
+    RustLib.instance.api.crateApiAudioApiClearDsdNativeFailure();
 
 Future<void> clearDsdTrackRate() =>
     RustLib.instance.api.crateApiAudioApiClearDsdTrackRate();
@@ -147,6 +153,16 @@ void audioSetDsdBitReverseOverride({required bool enabled}) => RustLib
     .instance
     .api
     .crateApiAudioApiAudioSetDsdBitReverseOverride(enabled: enabled);
+
+/// Wire-packing variant for the DAP-internal native-DSD shim transport:
+/// 0 = Auto/BE-MSB, 1 = LE-MSB, 2 = BE-LSB, 3 = LE-LSB. Wrong = hiss.
+void audioSetSasWireVariant({required int variant}) => RustLib.instance.api
+    .crateApiAudioApiAudioSetSasWireVariant(variant: variant);
+
+/// Wire byte grouping (subslot width) for the DAP-internal native-DSD shim:
+/// 0 = U32 (legacy), 1 = U16, 2 = U8 (byte-interleaved). Wrong = hiss.
+void audioSetSasWireGrouping({required int grouping}) => RustLib.instance.api
+    .crateApiAudioApiAudioSetSasWireGrouping(grouping: grouping);
 
 /// Force the native-DSD wire byte order on the USB direct transport (DSD_U32
 /// packing). Pass `None` to defer to the device quirk (auto). Use to diagnose

--- a/lib/src/rust/api/scanner.dart
+++ b/lib/src/rust/api/scanner.dart
@@ -6,7 +6,7 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `classify_scan_work`, `collect_file_entries`, `collect_playlist_file_entries`, `collect_scan_file_entries`, `directory_is_nomedia_blocked`, `extract_dff_artwork`, `extract_dff_metadata`, `extract_dsf_artwork`, `extract_dsf_metadata`, `extract_lofty_artwork`, `extract_lofty_metadata`, `extract_text_metadata_only`, `extract_wavpack_metadata`, `id3_replaygains`, `is_in_nomedia_subtree`, `is_supported_audio_path`, `is_supported_playlist_path`, `lofty_replaygains`, `parse_rg_db`, `parse_rg_peak`
+// These functions are ignored because they are not marked as `pub`: `ape_cover_item`, `classify_scan_work`, `collect_file_entries`, `collect_playlist_file_entries`, `collect_scan_file_entries`, `directory_is_nomedia_blocked`, `extract_dff_artwork`, `extract_dff_metadata`, `extract_dsf_artwork`, `extract_dsf_metadata`, `extract_lofty_artwork`, `extract_lofty_metadata`, `extract_text_metadata_only`, `extract_wavpack_metadata`, `find_dff_id3_tag`, `id3_replaygains`, `is_in_nomedia_subtree`, `is_supported_audio_path`, `is_supported_playlist_path`, `lofty_replaygains`, `parse_rg_db`, `parse_rg_peak`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `FileScanEntry`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
 

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 396510651;
+  int get rustContentHash => 1865297264;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -278,6 +278,10 @@ abstract class RustLibApi extends BaseApi {
     required double gainDb,
   });
 
+  void crateApiAudioApiAudioSetSasWireGrouping({required int grouping});
+
+  void crateApiAudioApiAudioSetSasWireVariant({required int variant});
+
   Future<void> crateApiAudioApiAudioSetVolume({required double volume});
 
   Future<void> crateApiAudioApiAudioShutdown();
@@ -291,6 +295,8 @@ abstract class RustLibApi extends BaseApi {
     required Map<String, PlatformInt64> knownFiles,
     required ScanOptions scanOptions,
   });
+
+  Future<void> crateApiAudioApiClearDsdNativeFailure();
 
   Future<void> crateApiAudioApiClearDsdTrackRate();
 
@@ -323,6 +329,8 @@ abstract class RustLibApi extends BaseApi {
   String crateApiSimpleGreet({required String name});
 
   Future<void> crateApiSimpleInitApp();
+
+  Future<String?> crateApiAudioApiLastDsdNativeFailure();
 
   Future<double> crateApiAudioApiLastVolume();
 
@@ -2192,6 +2200,58 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  void crateApiAudioApiAudioSetSasWireGrouping({required int grouping}) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_u_8(grouping, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiAudioApiAudioSetSasWireGroupingConstMeta,
+        argValues: [grouping],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiAudioApiAudioSetSasWireGroupingConstMeta =>
+      const TaskConstMeta(
+        debugName: "audio_set_sas_wire_grouping",
+        argNames: ["grouping"],
+      );
+
+  @override
+  void crateApiAudioApiAudioSetSasWireVariant({required int variant}) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_u_8(variant, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiAudioApiAudioSetSasWireVariantConstMeta,
+        argValues: [variant],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiAudioApiAudioSetSasWireVariantConstMeta =>
+      const TaskConstMeta(
+        debugName: "audio_set_sas_wire_variant",
+        argNames: ["variant"],
+      );
+
+  @override
   Future<void> crateApiAudioApiAudioSetVolume({required double volume}) {
     return handler.executeNormal(
       NormalTask(
@@ -2201,7 +2261,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2228,7 +2288,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 62,
             port: port_,
           );
         },
@@ -2255,7 +2315,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 63,
             port: port_,
           );
         },
@@ -2282,7 +2342,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 64,
             port: port_,
           );
         },
@@ -2316,7 +2376,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 65,
             port: port_,
           );
         },
@@ -2338,6 +2398,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<void> crateApiAudioApiClearDsdNativeFailure() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 66,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiAudioApiClearDsdNativeFailureConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiAudioApiClearDsdNativeFailureConstMeta =>
+      const TaskConstMeta(debugName: "clear_dsd_native_failure", argNames: []);
+
+  @override
   Future<void> crateApiAudioApiClearDsdTrackRate() {
     return handler.executeNormal(
       NormalTask(
@@ -2346,7 +2433,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 67,
             port: port_,
           );
         },
@@ -2373,7 +2460,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 65,
+            funcId: 68,
             port: port_,
           );
         },
@@ -2400,7 +2487,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 69,
             port: port_,
           );
         },
@@ -2432,7 +2519,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 70,
             port: port_,
           );
         },
@@ -2465,7 +2552,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 71,
             port: port_,
           );
         },
@@ -2500,7 +2587,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 69,
+            funcId: 72,
             port: port_,
           );
         },
@@ -2533,7 +2620,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 70,
+            funcId: 73,
             port: port_,
           );
         },
@@ -2566,7 +2653,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 71,
+            funcId: 74,
             port: port_,
           );
         },
@@ -2594,7 +2681,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2619,7 +2706,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 76,
             port: port_,
           );
         },
@@ -2638,6 +2725,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "init_app", argNames: []);
 
   @override
+  Future<String?> crateApiAudioApiLastDsdNativeFailure() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 77,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_opt_String,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiAudioApiLastDsdNativeFailureConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiAudioApiLastDsdNativeFailureConstMeta =>
+      const TaskConstMeta(debugName: "last_dsd_native_failure", argNames: []);
+
+  @override
   Future<double> crateApiAudioApiLastVolume() {
     return handler.executeNormal(
       NormalTask(
@@ -2646,7 +2760,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 78,
             port: port_,
           );
         },
@@ -2676,7 +2790,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 79,
             port: port_,
           );
         },
@@ -2707,7 +2821,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 80,
             port: port_,
           );
         },
@@ -2737,7 +2851,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 77,
+              funcId: 81,
               port: port_,
             );
           },
@@ -2776,7 +2890,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 78,
+              funcId: 82,
               port: port_,
             );
           },
@@ -2815,7 +2929,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 83,
             port: port_,
           );
         },
@@ -2845,7 +2959,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 84,
             port: port_,
           );
         },
@@ -2877,7 +2991,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 85,
             port: port_,
           );
         },
@@ -2910,7 +3024,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 86,
             port: port_,
           );
         },
@@ -2941,7 +3055,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 87,
             port: port_,
           );
         },
@@ -2976,7 +3090,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 88,
             port: port_,
           );
         },
@@ -3007,7 +3121,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 89,
             port: port_,
           );
         },
@@ -3055,7 +3169,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 86,
+              funcId: 90,
               port: port_,
             );
           },
@@ -3112,7 +3226,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 87,
+              funcId: 91,
               port: port_,
             );
           },
@@ -3154,7 +3268,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 92,
             port: port_,
           );
         },
@@ -3196,7 +3310,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 93,
             port: port_,
           );
         },
@@ -3226,7 +3340,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 94,
             port: port_,
           );
         },
@@ -3254,7 +3368,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 95,
             port: port_,
           );
         },
@@ -3281,7 +3395,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 96,
             port: port_,
           );
         },
@@ -3309,7 +3423,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 97,
             port: port_,
           );
         },
@@ -3336,7 +3450,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 98,
             port: port_,
           );
         },
@@ -3363,7 +3477,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 99,
             port: port_,
           );
         },
@@ -3390,7 +3504,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 100,
             port: port_,
           );
         },
@@ -3417,7 +3531,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 101,
             port: port_,
           );
         },
@@ -3441,7 +3555,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 98)!;
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 102,
+          )!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3466,7 +3584,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 103,
+          )!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_uac_2_connection_state,
@@ -3494,7 +3616,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 104,
             port: port_,
           );
         },
@@ -3524,7 +3646,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 105,
           )!;
         },
         codec: SseCodec(
@@ -3550,7 +3672,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 106,
           )!;
         },
         codec: SseCodec(
@@ -3576,7 +3698,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 107,
           )!;
         },
         codec: SseCodec(
@@ -3605,7 +3727,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 108,
           )!;
         },
         codec: SseCodec(
@@ -3631,7 +3753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 109,
             port: port_,
           );
         },
@@ -3658,7 +3780,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 110,
           )!;
         },
         codec: SseCodec(
@@ -3684,7 +3806,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 111,
           )!;
         },
         codec: SseCodec(
@@ -3713,7 +3835,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 112,
           )!;
         },
         codec: SseCodec(
@@ -3742,7 +3864,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 113,
             port: port_,
           );
         },
@@ -3773,7 +3895,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 114,
             port: port_,
           );
         },
@@ -3804,7 +3926,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 115,
             port: port_,
           );
         },
@@ -3834,7 +3956,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 116,
             port: port_,
           );
         },
@@ -3865,7 +3987,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 117,
             port: port_,
           );
         },
@@ -3895,7 +4017,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 118,
             port: port_,
           );
         },
@@ -3925,7 +4047,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 119,
             port: port_,
           );
         },
@@ -3957,7 +4079,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 120,
             port: port_,
           );
         },
@@ -3992,7 +4114,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 121,
             port: port_,
           );
         },
@@ -4029,7 +4151,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 122,
             port: port_,
           );
         },

--- a/lib/widgets/uac2/uac2_player_status.dart
+++ b/lib/widgets/uac2/uac2_player_status.dart
@@ -72,7 +72,9 @@ class Uac2PlayerStatus extends ConsumerWidget {
           if (status.currentFormat != null && showFormat) ...[
             const SizedBox(width: 4),
             Text(
-              '${_effectiveSampleRate(status, diagnostics) ~/ 1000}kHz/${status.currentFormat!.bitDepth}bit',
+              status.currentFormat!.isDsdStream
+                  ? status.currentFormat!.compactRateLabel
+                  : '${_effectiveSampleRate(status, diagnostics) ~/ 1000}kHz/${status.currentFormat!.bitDepth}bit',
               style: TextStyle(
                 fontSize: 10,
                 color: _getStatusColor(status.state),
@@ -179,12 +181,14 @@ class Uac2PlayerStatus extends ConsumerWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 _buildFormatBadge(
-                  '${_effectiveSampleRate(status, diagnostics) ~/ 1000}kHz',
+                  status.currentFormat!.isDsdStream
+                      ? status.currentFormat!.compactRateLabel
+                      : '${_effectiveSampleRate(status, diagnostics) ~/ 1000}kHz',
                   context,
                 ),
                 const SizedBox(width: 4),
                 _buildFormatBadge(
-                  '${status.currentFormat!.bitDepth}bit',
+                  status.currentFormat!.bitDepthLabel,
                   context,
                 ),
                 const SizedBox(width: 4),

--- a/lib/widgets/uac2/uac2_status_indicator.dart
+++ b/lib/widgets/uac2/uac2_status_indicator.dart
@@ -46,7 +46,9 @@ class Uac2StatusIndicator extends ConsumerWidget {
           if (deviceStatus.currentFormat != null) ...[
             const SizedBox(width: 4),
             Text(
-              '${_effectiveSampleRate(deviceStatus, diagnostics) ~/ 1000}kHz/${deviceStatus.currentFormat!.bitDepth}bit',
+              deviceStatus.currentFormat!.isDsdStream
+                  ? deviceStatus.currentFormat!.compactRateLabel
+                  : '${_effectiveSampleRate(deviceStatus, diagnostics) ~/ 1000}kHz/${deviceStatus.currentFormat!.bitDepth}bit',
               style: TextStyle(
                 fontSize: 10,
                 color: _getStatusColor(

--- a/rust/src/api/audio_api.rs
+++ b/rust/src/api/audio_api.rs
@@ -27,7 +27,9 @@ use std::sync::Mutex;
 
 static ENGINE_MANAGER: Lazy<EngineManager> = Lazy::new(EngineManager::new);
 
-static DSD_OUTPUT_MODE: AtomicU8 = AtomicU8::new(0);
+// Default Auto, not PcmDecimation: FRB runs calls on a worker pool, so the
+// Dart-side sync can race the first audio_play. Never decimate DSD to PCM.
+static DSD_OUTPUT_MODE: AtomicU8 = AtomicU8::new(3);
 static CURRENT_DSD_TRACK_RATE: AtomicU32 = AtomicU32::new(0);
 static PENDING_VOLUME: AtomicU32 = AtomicU32::new(0);
 
@@ -198,6 +200,34 @@ pub fn effective_dsd_output_mode_for_rate(
 
 pub fn set_dsd_track_rate(rate: u32) {
     CURRENT_DSD_TRACK_RATE.store(rate, Ordering::Relaxed);
+}
+
+// Why the last native-DSD attempt fell back (SAS offload / ALSA reasons), so
+// diagnostics can say more than "native unavailable".
+static LAST_DSD_NATIVE_FAILURE: Lazy<Mutex<Option<String>>> =
+    Lazy::new(|| Mutex::new(None));
+
+pub fn last_dsd_native_failure() -> Option<String> {
+    LAST_DSD_NATIVE_FAILURE
+        .lock()
+        .ok()
+        .and_then(|guard| guard.clone())
+}
+
+pub fn clear_dsd_native_failure() {
+    if let Ok(mut guard) = LAST_DSD_NATIVE_FAILURE.lock() {
+        *guard = None;
+    }
+}
+
+fn record_dsd_native_failure(error: &str) {
+    let reason = error
+        .strip_prefix("DSD_NATIVE_FALLBACK:")
+        .unwrap_or(error)
+        .to_string();
+    if let Ok(mut guard) = LAST_DSD_NATIVE_FAILURE.lock() {
+        *guard = Some(reason);
+    }
 }
 
 pub fn clear_dsd_track_rate() {
@@ -712,6 +742,7 @@ pub fn audio_is_native_available() -> bool {
 /// Initialize the audio engine.
 #[flutter_rust_bridge::frb(sync)]
 pub fn audio_init() -> Result<(), String> {
+    crate::assert_android_debug_logging();
     ENGINE_MANAGER.init();
     Ok(())
 }
@@ -806,6 +837,20 @@ pub fn audio_set_dsd_output_mode(mode: u8) {
 #[flutter_rust_bridge::frb(sync)]
 pub fn audio_set_dsd_bit_reverse_override(enabled: bool) {
     crate::audio::dsd_engine::output::set_dsd_bit_reverse_override(enabled);
+}
+
+/// Wire-packing variant for the DAP-internal native-DSD shim transport:
+/// 0 = Auto/BE-MSB, 1 = LE-MSB, 2 = BE-LSB, 3 = LE-LSB. Wrong = hiss.
+#[flutter_rust_bridge::frb(sync)]
+pub fn audio_set_sas_wire_variant(variant: u8) {
+    crate::audio::dsd_sas_shim::set_wire_variant(variant.min(3));
+}
+
+/// Wire byte grouping (subslot width) for the DAP-internal native-DSD shim:
+/// 0 = U32 (legacy), 1 = U16, 2 = U8 (byte-interleaved). Wrong = hiss.
+#[flutter_rust_bridge::frb(sync)]
+pub fn audio_set_sas_wire_grouping(grouping: u8) {
+    crate::audio::dsd_sas_shim::set_wire_grouping(grouping);
 }
 
 /// Force the native-DSD wire byte order on the USB direct transport (DSD_U32
@@ -972,6 +1017,7 @@ pub fn audio_probe_format(path: String) -> Result<AudioProbeFormat, String> {
 
 /// Play an audio file.
 pub fn audio_play(path: String) -> Result<(), String> {
+    crate::assert_android_debug_logging();
     let path = PathBuf::from(&path);
     match detect_file_type(&path) {
         crate::audio::decoder_handle::FileType::Dsd => {
@@ -983,8 +1029,15 @@ pub fn audio_play(path: String) -> Result<(), String> {
             };
             let dsd_rate_enum = DsdRate::from_sample_rate(dsd_sample_rate);
             set_dsd_track_rate(dsd_sample_rate);
+            clear_dsd_native_failure();
             let mut effective_mode =
                 effective_dsd_output_mode_for_rate(requested_mode, dsd_rate_enum);
+            log_info!(
+                "[AUDIO] DSD play: requested={:?} dsd_rate={} effective={:?}",
+                requested_mode,
+                dsd_sample_rate,
+                effective_mode
+            );
             if matches!(effective_mode, DsdOutputMode::Native | DsdOutputMode::Auto) {
                 crate::audio::dsd_native_jni::dsd_track_preload_class();
             }
@@ -992,6 +1045,7 @@ pub fn audio_play(path: String) -> Result<(), String> {
                 ensure_audio_engine(resolve_dsd_engine_sample_rate(&path, effective_mode)?)
             {
                 if e.starts_with("DSD_NATIVE_FALLBACK:") {
+                    record_dsd_native_failure(&e);
                     log::info!(
                         "[AUDIO] DSD Native unavailable ({}), falling back to DoP",
                         e
@@ -1090,6 +1144,7 @@ pub fn audio_play(path: String) -> Result<(), String> {
 
 /// Queue the next track for gapless playback.
 pub fn audio_queue_next(path: String) -> Result<(), String> {
+    crate::assert_android_debug_logging();
     let path = PathBuf::from(path);
     if !audio_is_initialized() {
         match detect_file_type(&path) {
@@ -1102,8 +1157,15 @@ pub fn audio_queue_next(path: String) -> Result<(), String> {
                 };
                 let dsd_rate_enum = DsdRate::from_sample_rate(dsd_sample_rate);
                 set_dsd_track_rate(dsd_sample_rate);
+                clear_dsd_native_failure();
                 let mut effective_mode =
                     effective_dsd_output_mode_for_rate(requested_mode, dsd_rate_enum);
+                log_info!(
+                    "[AUDIO] DSD queue_next: requested={:?} dsd_rate={} effective={:?}",
+                    requested_mode,
+                    dsd_sample_rate,
+                    effective_mode
+                );
                 if matches!(effective_mode, DsdOutputMode::Native | DsdOutputMode::Auto) {
                     crate::audio::dsd_native_jni::dsd_track_preload_class();
                 }
@@ -1111,6 +1173,7 @@ pub fn audio_queue_next(path: String) -> Result<(), String> {
                     ensure_audio_engine(resolve_dsd_engine_sample_rate(&path, effective_mode)?)
                 {
                     if e.starts_with("DSD_NATIVE_FALLBACK:") {
+                        record_dsd_native_failure(&e);
                         log::info!(
                             "[AUDIO] DSD Native unavailable ({}), falling back to DoP",
                             e

--- a/rust/src/audio/device.rs
+++ b/rust/src/audio/device.rs
@@ -228,12 +228,31 @@ pub fn classify_device(signals: DeviceSignals) -> DeviceProfile {
             }
             probe
         };
+    // Vendor offload shim: libsmartaudioservice.so (public on DAP firmware)
+    // creates framework DSD_NATIVE AudioTracks — the stock player's path and
+    // the only native route on SELinux-locked DAPs. Cheap dlopen check.
+    let native_dsd_from_sas =
+        is_dap && !native_dsd_from_caps && !native_dsd_from_runtime && {
+            let available = crate::audio::dsd_sas_shim::probe_available();
+            if available {
+                log::info!(
+                    "[DSD-NATIVE] SAS offload shim available for {:?} (libsmartaudioservice.so)",
+                    kind
+                );
+            } else if let Some(reason) = crate::audio::dsd_sas_shim::probe_unavailable_reason() {
+                log::info!("[DSD-NATIVE] SAS offload shim unavailable: {}", reason);
+            }
+            available
+        };
     DeviceProfile {
         confirmed_bit_perfect: is_dap,
         kind,
         max_sample_rate: signals.audio_caps.max_sample_rate,
         has_balanced_output: signals.audio_caps.has_balanced_output,
-        supports_native_dsd: native_dsd_from_caps || native_dsd_from_runtime || native_dsd_from_alsa,
+        supports_native_dsd: native_dsd_from_caps
+            || native_dsd_from_runtime
+            || native_dsd_from_alsa
+            || native_dsd_from_sas,
     }
 }
 

--- a/rust/src/audio/dsd_engine/dsd/dop.rs
+++ b/rust/src/audio/dsd_engine/dsd/dop.rs
@@ -5,16 +5,28 @@ pub struct DopPacker {
     channels: usize,
     marker_state: u8,
     dsd_bytes_per_ch: usize,
+    needs_bit_reverse: bool,
 }
 
 impl DopPacker {
     pub fn new(dsd_rate: DsdRate, channels: usize) -> Self {
+        Self::with_bit_reverse(dsd_rate, channels, false)
+    }
+
+    /// `needs_bit_reverse` covers sources stored LSB-first (DSF): the DoP
+    /// wire is MSB-first, so bytes must be reversed before packing.
+    pub fn with_bit_reverse(
+        dsd_rate: DsdRate,
+        channels: usize,
+        needs_bit_reverse: bool,
+    ) -> Self {
         let dsd_bytes_per_ch = dsd_rate.dsd_bytes_per_channel_per_dop_frame();
         Self {
             dsd_rate,
             channels,
             marker_state: 0x05,
             dsd_bytes_per_ch,
+            needs_bit_reverse,
         }
     }
 
@@ -96,7 +108,13 @@ impl DopPacker {
             let read_pos = frame_byte_offset + byte_idx;
             if read_pos < dsd_bytes.len() {
                 let shift = dsd_data_bits - 8 * (byte_idx + 1);
-                sample |= (dsd_bytes[read_pos] as u32) << shift;
+                let byte = dsd_bytes[read_pos];
+                let byte = if self.needs_bit_reverse {
+                    byte.reverse_bits()
+                } else {
+                    byte
+                };
+                sample |= (byte as u32) << shift;
             }
         }
 

--- a/rust/src/audio/dsd_engine/dsd_thread.rs
+++ b/rust/src/audio/dsd_engine/dsd_thread.rs
@@ -53,7 +53,8 @@ impl DsdDecoderThread {
         };
 
         log::info!(
-            "[DSD-DECODER] spawn: file_rate={} Hz, dsd_rate={:?}, output_mode={:?}, target_rate={} Hz, output_rate={} Hz",
+            "[DSD-DECODER] spawn: path={}, file_rate={} Hz, dsd_rate={:?}, output_mode={:?}, target_rate={} Hz, output_rate={} Hz",
+            path.display(),
             decoder.sample_rate(),
             dsd_rate,
             output_mode,
@@ -193,6 +194,30 @@ fn dsd_decode_thread(
     let mut dsd_buf = vec![0u8; read_size];
     let mut output_buf: Vec<f32> = Vec::with_capacity(DSD_READ_CHUNK_SIZE);
 
+    // Offline wire-vs-reference diffing. Only the first decoder thread to
+    // claim the flag dumps, so a gapless preload decoder can't interleave.
+    static DUMP_CLAIMED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    let dump_enabled = !DUMP_CLAIMED.swap(true, Ordering::AcqRel);
+    let mut dump_raw: Option<std::fs::File> = None;
+    let mut dump_prod: Option<std::fs::File> = None;
+    let mut dump_raw_n: usize = 0;
+    let mut dump_prod_n: usize = 0;
+    if dump_enabled {
+        use std::fs::OpenOptions;
+        let dir = std::path::Path::new("/storage/6438-6261/flick_dsd_dump");
+        let _ = std::fs::create_dir_all(dir);
+        dump_raw = OpenOptions::new()
+            .create(true).write(true).truncate(true)
+            .open(dir.join("dsd_raw_full.bin")).ok();
+        dump_prod = OpenOptions::new()
+            .create(true).write(true).truncate(true)
+            .open(dir.join("dsd_prod_full.bin")).ok();
+        log::info!(
+            "[DSD-DECODER] dump capture claimed (raw+prod), read_size={}",
+            read_size
+        );
+    }
+
     log::info!(
         "[DSD-DECODER] Starting: dsd_rate={} channels={} layout={:?} bit_order={:?}",
         decoder.sample_rate(),
@@ -209,6 +234,15 @@ fn dsd_decode_thread(
         let bytes_read = decoder.read_dsd_bytes(&mut dsd_buf)?;
         if bytes_read == 0 {
             break;
+        }
+
+        if let Some(f) = dump_raw.as_mut() {
+            if dump_raw_n < (5 << 20) {
+                use std::io::Write;
+                let cap = ((5 << 20) - dump_raw_n).min(bytes_read);
+                let _ = f.write_all(&dsd_buf[..cap]);
+                dump_raw_n += cap;
+            }
         }
 
         let (data, offsets) = match &channel_layout {
@@ -234,6 +268,19 @@ fn dsd_decode_thread(
         {
             log::error!("[DSD-DECODER] Processing error: {}", e);
             break;
+        }
+
+        if let Some(f) = dump_prod.as_mut() {
+            if dump_prod_n < (5 << 20) {
+                use std::io::Write;
+                let mut tmp: Vec<u8> = Vec::with_capacity(output_buf.len());
+                for s in &output_buf {
+                    tmp.push(s.to_bits() as u8);
+                }
+                let cap = ((5 << 20) - dump_prod_n).min(tmp.len());
+                let _ = f.write_all(&tmp[..cap]);
+                dump_prod_n += cap;
+            }
         }
 
         write_to_ring_buffer(&output_buf, &mut producer, &stop_signal);

--- a/rust/src/audio/dsd_engine/format/dff_decoder.rs
+++ b/rust/src/audio/dsd_engine/format/dff_decoder.rs
@@ -85,7 +85,17 @@ impl DsdFormatDecoder for DffDecoder {
             return Ok(0);
         }
 
-        let bytes_read = self.file.read(buf)?;
+        // FUSE-backed storage routinely returns short reads; fill the buffer
+        // fully so interleaved channel pairs are never split.
+        let mut bytes_read = 0usize;
+        while bytes_read < buf.len() {
+            match self.file.read(&mut buf[bytes_read..]) {
+                Ok(0) => break,
+                Ok(n) => bytes_read += n,
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e.into()),
+            }
+        }
         if bytes_read == 0 {
             self.finished = true;
         }

--- a/rust/src/audio/dsd_engine/format/dsf_decoder.rs
+++ b/rust/src/audio/dsd_engine/format/dsf_decoder.rs
@@ -105,7 +105,18 @@ impl DsdFormatDecoder for DsfDecoder {
             return Ok(0);
         }
 
-        let bytes_read = self.file.read(buf)?;
+        // FUSE-backed storage routinely returns short reads; keep reading so
+        // the consumer always gets whole macro blocks (a truncated tail would
+        // silently desync the per-channel blocks and tick audibly).
+        let mut bytes_read = 0usize;
+        while bytes_read < buf.len() {
+            match self.file.read(&mut buf[bytes_read..]) {
+                Ok(0) => break,
+                Ok(n) => bytes_read += n,
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e.into()),
+            }
+        }
         if bytes_read == 0 {
             self.finished = true;
         }

--- a/rust/src/audio/dsd_engine/output/mod.rs
+++ b/rust/src/audio/dsd_engine/output/mod.rs
@@ -97,7 +97,11 @@ impl DsdOutputRouter {
         };
 
         let dop_packer = match mode {
-            DsdOutputMode::Dop => Some(DopPacker::new(dsd_rate, channels)),
+            DsdOutputMode::Dop => Some(DopPacker::with_bit_reverse(
+                dsd_rate,
+                channels,
+                dop_needs_bit_reverse(source_bit_order),
+            )),
             DsdOutputMode::PcmDecimation | DsdOutputMode::Native | DsdOutputMode::Auto => None,
         };
 
@@ -179,6 +183,15 @@ fn normalize_dsd_byte(byte: u8, source_order: DsdBitOrder) -> u8 {
         reverse_bits(byte)
     } else {
         byte
+    }
+}
+
+fn dop_needs_bit_reverse(source_order: DsdBitOrder) -> bool {
+    let source_lsb = matches!(source_order, DsdBitOrder::LsbFirst);
+    if DSD_BIT_REVERSE_OVERRIDE.load(Ordering::Relaxed) {
+        !source_lsb
+    } else {
+        source_lsb
     }
 }
 

--- a/rust/src/audio/dsd_native_backend.rs
+++ b/rust/src/audio/dsd_native_backend.rs
@@ -14,15 +14,85 @@ pub struct DsdNativeBackend {
 }
 
 impl DsdNativeBackend {
-    /// Opens native DSD output via direct ALSA ioctl (bypasses AudioTrack
-    /// and AudioFlinger entirely).  `sample_rate` is the DSD byte rate
+    /// Opens native DSD output. `sample_rate` is the DSD byte rate
     /// (352 800 for DSD64, 705 600 for DSD128).
+    ///
+    /// Transports, in preference order: the vendor offload shim (framework
+    /// DSD_NATIVE AudioTrack via `libsmartaudioservice.so` — the only route
+    /// reachable on SELinux-locked DAPs), then direct ALSA ioctls on
+    /// `/dev/snd/pcmC*D*p` (rooted/friendly ROMs).
     pub fn start(
         callback_data: Arc<AudioCallbackData>,
         event_tx: Sender<AudioEvent>,
         sample_rate: u32,
         channels: usize,
     ) -> Result<Self, String> {
+        #[cfg(target_os = "android")]
+        let bit_rate = sample_rate * 8;
+        #[cfg_attr(not(target_os = "android"), allow(unused_mut))]
+        let mut sas_failure: Option<String> = None;
+
+        #[cfg(target_os = "android")]
+        if channels == 2 {
+            match super::dsd_sas_shim::create_dsd_track(bit_rate) {
+                Ok(track) => {
+                    // DSD wire silence (0x69): 0.0 fills pack to DC and crackle.
+                    let flag_handle = Arc::clone(&callback_data);
+                    flag_handle.set_dsd_wire_silence(true);
+                    crate::dev_eprintln!(
+                        "[DSD-NATIVE] SAS offload track opened: bit_rate={} Hz (wire {} Hz) — framework DSD_NATIVE AudioTrack, launching render thread",
+                        bit_rate,
+                        track.wire_rate(),
+                    );
+                    let stop = Arc::new(AtomicBool::new(false));
+                    let stop_clone = Arc::clone(&stop);
+                    // The track crosses into the render thread; keep a handle
+                    // so a spawn failure can still release it.
+                    let track_holder = Arc::new(std::sync::Mutex::new(Some(track)));
+                    let holder_for_thread = Arc::clone(&track_holder);
+                    let spawn_result = thread::Builder::new()
+                        .name("dsd-native-render".to_string())
+                        .spawn(move || {
+                            if let Some(track) = holder_for_thread.lock().unwrap().take() {
+                                dsd_sas_render_loop(
+                                    track,
+                                    callback_data,
+                                    event_tx,
+                                    sample_rate,
+                                    channels,
+                                    stop_clone,
+                                );
+                            }
+                        });
+                    let handle = match spawn_result {
+                        Ok(handle) => handle,
+                        Err(e) => {
+                            flag_handle.set_dsd_wire_silence(false);
+                            if let Some(track) = track_holder.lock().unwrap().take() {
+                                track.release();
+                            }
+                            return Err(format!("Failed to spawn DSD render thread: {}", e));
+                        }
+                    };
+                    super::dsd_sas_shim::set_active_transport(
+                        super::dsd_sas_shim::TRANSPORT_SAS_OFFLOAD,
+                    );
+                    return Ok(Self {
+                        stop,
+                        render_thread: Some(handle),
+                    });
+                }
+                Err(reason) => {
+                    log::warn!(
+                        "[DSD-NATIVE] SAS offload unavailable at bit_rate={} Hz: {}",
+                        bit_rate,
+                        reason
+                    );
+                    sas_failure = Some(reason);
+                }
+            }
+        }
+
         log::info!(
             "[DSD-NATIVE] Opening ALSA direct DSD output: byte_rate={} Hz, ch={}",
             sample_rate,
@@ -35,10 +105,14 @@ impl DsdNativeBackend {
                 sample_rate,
                 channels,
             );
-            return Err(format!(
+            let alsa_reason = format!(
                 "ALSA DSD output unavailable at byte_rate={} ch={}",
                 sample_rate, channels
-            ));
+            );
+            return Err(match sas_failure {
+                Some(sas) => format!("SAS offload: {}; {}", sas, alsa_reason),
+                None => alsa_reason,
+            });
         }
 
         crate::dev_eprintln!(
@@ -47,16 +121,23 @@ impl DsdNativeBackend {
             channels,
         );
 
-        let stop = Arc::new(AtomicBool::new(false));
-        let stop_clone = Arc::clone(&stop);
+    let flag_handle = Arc::clone(&callback_data);
+    flag_handle.set_dsd_wire_silence(true);
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_clone = Arc::clone(&stop);
 
-        let handle = thread::Builder::new()
-            .name("dsd-native-render".to_string())
-            .spawn(move || {
-                dsd_native_render_loop(callback_data, event_tx, sample_rate, channels, stop_clone);
-                super::dsd_alsa_direct::dsd_alsa_close();
-            })
-            .map_err(|e| format!("Failed to spawn DSD render thread: {}", e))?;
+    let handle = thread::Builder::new()
+        .name("dsd-native-render".to_string())
+        .spawn(move || {
+            dsd_native_render_loop(callback_data, event_tx, sample_rate, channels, stop_clone);
+            super::dsd_alsa_direct::dsd_alsa_close();
+        })
+        .map_err(|e| {
+            flag_handle.set_dsd_wire_silence(false);
+            format!("Failed to spawn DSD render thread: {}", e)
+        })?;
+
+        super::dsd_sas_shim::set_active_transport(super::dsd_sas_shim::TRANSPORT_ALSA_DIRECT);
 
         Ok(Self {
             stop,
@@ -71,8 +152,8 @@ impl DsdNativeBackend {
         }
     }
 
-    pub fn is_alsa(&self) -> bool {
-        true
+    pub fn transport_name(&self) -> &'static str {
+        super::dsd_sas_shim::native_transport_name()
     }
 }
 
@@ -119,14 +200,137 @@ fn dsd_native_render_loop(
         }
     }
 
+    callback_data.set_dsd_wire_silence(false);
     log::info!("[DSD-NATIVE] ALSA render loop ended");
+}
+
+#[cfg(target_os = "android")]
+fn dsd_sas_render_loop(
+    track: super::dsd_sas_shim::SasTrack,
+    callback_data: Arc<AudioCallbackData>,
+    event_tx: Sender<AudioEvent>,
+    byte_rate: u32,
+    channels: usize,
+    stop: Arc<AtomicBool>,
+) {
+    // Write granularity is probe-verified in create_dsd_track: the offload
+    // HAL returns 0 for sub-frame-unit writes. Each f32 packs to one wire
+    // byte, so chunk_samples == write_size regardless of grouping.
+    let write_size = track.write_size(); // bytes per write call
+    let group = super::dsd_sas_shim::wire_group_bytes(); // subslot bytes per channel
+    let wire_frames = write_size / (group * 2); // stereo frames per write
+    let chunk_frames = wire_frames * group; // DSD frames (bytes per channel)
+    let chunk_samples = chunk_frames * channels;
+    let mut render_buffer = vec![0.0f32; chunk_samples];
+    let mut wire_buf = vec![0u8; write_size];
+    let mut full_dump: Option<std::fs::File> = None;
+    let mut total_written: usize = 0;
+
+    log::info!(
+        "[DSD-NATIVE] SAS render loop started: bit_rate={} Hz (wire {} Hz), chunk={} frames, write={} B",
+        track.bit_rate(),
+        track.wire_rate(),
+        chunk_frames,
+        write_size
+    );
+
+    // Prefill gate: pulling early injects a whole chunk of 0x69 silence
+    // (audible pop on play/seek). Wait for one chunk first.
+    {
+        use std::time::{Duration, Instant};
+        let min_level =
+            chunk_samples as f32 / crate::audio::source::SOURCE_BUFFER_SIZE as f32;
+        let deadline = Instant::now() + Duration::from_millis(2_000);
+        while !stop.load(Ordering::Acquire) {
+            let ready = callback_data
+                .lock_sources_rt()
+                .and_then(|sources| {
+                    sources
+                        .current()
+                        .map(|s| s.has_enough_buffer() || s.buffer_level() >= min_level)
+                });
+            match ready {
+                Some(true) => break,
+                _ if Instant::now() >= deadline => {
+                    log::warn!(
+                        "[DSD-NATIVE] prefill gate timeout (level < {:.2}); proceeding",
+                        min_level
+                    );
+                    break;
+                }
+                _ => std::thread::sleep(Duration::from_millis(10)),
+            }
+        }
+    }
+
+    // Starvation telemetry: growth mid-track = crackle signature; a one-time
+    // jump at start/end is benign drain.
+    let mut last_stats = callback_data.dsd_starve_stats();
+
+    while !stop.load(Ordering::Acquire) {
+        audio_callback(&mut render_buffer, &callback_data, &event_tx);
+
+        super::dsd_sas_shim::pack_wire_frames(&render_buffer, channels, &mut wire_buf);
+
+        // Wire capture for offline diffing against a reference decode:
+        // continuous dump of the first 5 MiB of wire bytes.
+        {
+            use std::fs::OpenOptions;
+            use std::io::Write;
+            use std::path::Path;
+            if total_written == 0 {
+                let dir = Path::new("/storage/6438-6261/flick_dsd_dump");
+                let _ = std::fs::create_dir_all(dir);
+                if let Ok(f) = OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .open(dir.join("dsd_wire_full.bin"))
+                {
+                    full_dump = Some(f);
+                }
+            }
+            if let Some(f) = full_dump.as_mut() {
+                if total_written < (5 << 20) {
+                    let cap = ((5 << 20) - total_written).min(write_size);
+                    let _ = f.write_all(&wire_buf[..cap]);
+                }
+            }
+            total_written += write_size;
+        }
+
+        let written = track.write(&wire_buf);
+        if written <= 0 || written as usize != write_size {
+            log::error!(
+                "[DSD-NATIVE] SAS write failed ({} of {} bytes), stopping render loop",
+                written,
+                write_size
+            );
+            break;
+        }
+
+        let stats = callback_data.dsd_starve_stats();
+        if stats != last_stats {
+            log::warn!(
+                "[DSD-NATIVE] starvation telemetry: +{} starved samples, +{} lock misses (totals {} / {})",
+                stats.0 - last_stats.0,
+                stats.1 - last_stats.1,
+                stats.0,
+                stats.1
+            );
+            last_stats = stats;
+        }
+    }
+
+    track.release();
+    callback_data.set_dsd_wire_silence(false);
+    log::info!("[DSD-NATIVE] SAS render loop ended");
 }
 
 /// Direct PCM output over the raw ALSA ioctl path (same AudioFlinger
 /// bypass as DSD native, but S32_LE PCM at the track's native rate).
-/// Used by the DapNative strategy on DAPs whose HAL resamples shared-mode
-/// streams (e.g. HiBy R4 locks its indicator to 48 kHz while reporting the
-/// requested rate back through AudioTrack/AAudio).
+/// For DAPs whose HAL resamples shared-mode streams (indicator stays at
+/// 48 kHz while reporting the requested rate).
 pub struct PcmAlsaBackend {
     stop: Arc<AtomicBool>,
     render_thread: Option<JoinHandle<()>>,

--- a/rust/src/audio/dsd_sas_shim.rs
+++ b/rust/src/audio/dsd_sas_shim.rs
@@ -1,0 +1,629 @@
+//! HiBy DSD offload shim: framework-native DSD AudioTrack through the vendor's
+//! public `libsmartaudioservice.so` (listed in `/system/etc/public.libraries.txt`,
+//! loadable by any app). This is the same path stock HiBy Music uses — a C++
+//! `AudioTrack` with `AUDIO_FORMAT_DSD_NATIVE` (0x1A000001) on the compressed
+//! offload output, routed by audio policy to the internal DAC.
+//!
+//! ABI reverse-engineered from the R4 firmware (see
+//! `docs/audio/dsd-native-dap-plan.md` §H):
+//!
+//! - `create_track(bit_rate, channels, fmt_type, 1) -> *mut SasObj` — a
+//!   0x58-byte vtable object (null on OOM or if the initial track creation
+//!   fails). fmt_type 5..10 selects DSD: the shim builds
+//!   `AudioTrack(AUDIO_STREAM_MUSIC, wire_rate = bit_rate/32,
+//!   AUDIO_FORMAT_DSD_NATIVE, stereo, COMPRESS_OFFLOAD)` where `bit_rate`
+//!   is the DSD bit rate (5 644 800 for DSD128). Stock HiBy Music calls it
+//!   as `(bit_rate, 2, 6, 1)` (logcat-verified on the R4).
+//! - Vtable slots are PLT-stub fn pointers stored in the object (first arg =
+//!   the object): `[0x00] write(buf, len) -> c_int` (blocking
+//!   `AudioTrack::write`; re-runs the lazy track creation when needed and
+//!   returns 0 then; on the direct path it returns `len` UNCONDITIONALLY,
+//!   ignoring the real write result), `[0x18] start`, `[0x20] flush`,
+//!   `[0x10] stop+teardown`, `[0x08] soft stop` (keeps the track),
+//!   `[0x28] stopped` (returns 1 while the track is alive:
+//!   `track ? !AudioTrack::stopped() : status != 4`), `[0x38] get_rate`,
+//!   `[0x40] get_channels`, `[0x30] latency`, `[0x50]` = ctx ptr.
+//! - `release_track(obj)` frees object + ctx.
+//!
+//! Wire data: stereo frames of two N-byte subslots (L then R), each subslot
+//! packing 8*N consecutive DSD bits of one channel; wire rate = bit_rate/32.
+//! N is runtime-selectable (`SasWireGrouping`): the audioserver opens the
+//! DSD output at wire_rate with 4 B/frame (e.g. 176 500 Hz × 4 for DSD128)
+//! = two 16-bit subslots, so U16 (LL|RR) is the evidence-backed default;
+//! U32 (ALSA `DSD_U32_BE`-style) and U8 (byte-interleaved) remain selectable
+//! for calibration. Bit order inside a subslot is covered by the four
+//! runtime-selectable `SasWireVariant` codes. DSD silence byte is 0x69
+//! (SACD convention; what stock's drain loop memsets before stop).
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// Active native transport, set by the backend so diagnostics can name it.
+pub const TRANSPORT_NONE: u8 = 0;
+pub const TRANSPORT_SAS_OFFLOAD: u8 = 1;
+pub const TRANSPORT_ALSA_DIRECT: u8 = 2;
+
+static ACTIVE_TRANSPORT: AtomicU8 = AtomicU8::new(TRANSPORT_NONE);
+
+pub fn set_active_transport(transport: u8) {
+    ACTIVE_TRANSPORT.store(transport, Ordering::Release);
+}
+
+pub fn native_transport_name() -> &'static str {
+    match ACTIVE_TRANSPORT.load(Ordering::Acquire) {
+        TRANSPORT_SAS_OFFLOAD => "dap-native-offload",
+        TRANSPORT_ALSA_DIRECT => "dap-native-alsa",
+        _ => "dap-native",
+    }
+}
+
+/// Wire-packing variant inside each subslot. Which one a vendor HAL
+/// expects is not observable without playback; combined with the grouping
+/// it spans the packing space (bit order × byte order × subslot width).
+///
+/// 0 = Auto (RawBe), 1 = RawLe, 2 = BitRevBe, 3 = BitRevLe.
+static WIRE_VARIANT: AtomicU8 = AtomicU8::new(0);
+
+pub fn set_wire_variant(variant: u8) {
+    WIRE_VARIANT.store(variant, Ordering::Relaxed);
+}
+
+pub fn wire_variant() -> u8 {
+    WIRE_VARIANT.load(Ordering::Relaxed)
+}
+
+/// Bytes per channel subslot in a wire frame. The audioserver stream is
+/// opened at `wire_rate` Hz with 4 bytes per stereo frame (logcat: DSD128 →
+/// 176 400 Hz, channel mask 0x3). On-device calibration (R4, 2026-08-30)
+/// picked plain byte interleaving LRLR — U8 is the default. U32 is the
+/// legacy/ALSA `DSD_U32_BE` shape, U16 the 16-bit-subslot reading.
+///
+/// 0 = U32 (legacy), 1 = U16, 2 = U8 (default, calibrated).
+static WIRE_GROUPING: AtomicU8 = AtomicU8::new(2);
+
+pub fn set_wire_grouping(grouping: u8) {
+    WIRE_GROUPING.store(grouping.min(2), Ordering::Relaxed);
+}
+
+pub fn wire_grouping() -> u8 {
+    WIRE_GROUPING.load(Ordering::Relaxed)
+}
+
+/// Bytes per channel subslot for the active grouping (4 / 2 / 1).
+pub fn wire_group_bytes() -> usize {
+    match wire_grouping() {
+        0 => 4,
+        2 => 1,
+        _ => 2,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SasWireVariant {
+    /// Subslot bytes in DSD stream order: `[b0, b1, b2, b3]`.
+    RawBe,
+    /// Subslot bytes reversed: `[b3, b2, b1, b0]`.
+    RawLe,
+    /// Bit-reversed bytes in stream order (LSB-first DSD, `DSD_U32_LE`-style).
+    BitRevBe,
+    /// Bit-reversed bytes reversed.
+    BitRevLe,
+}
+
+impl SasWireVariant {
+    fn from_code(code: u8) -> Self {
+        match code {
+            1 => Self::RawLe,
+            2 => Self::BitRevBe,
+            3 => Self::BitRevLe,
+            _ => Self::RawBe,
+        }
+    }
+
+    fn bit_reversed(self) -> bool {
+        matches!(self, Self::BitRevBe | Self::BitRevLe)
+    }
+
+    fn byte_reversed(self) -> bool {
+        matches!(self, Self::RawLe | Self::BitRevLe)
+    }
+}
+
+/// Packs frame-major interleaved DSD samples (DSD byte in the low 8 bits of
+/// each f32, as produced by the engine's DSD pipeline) into shim wire frames:
+/// `2 * g` bytes per frame = L subslot (g bytes, 8g DSD bits) + R subslot,
+/// where `g = wire_group_bytes()`. Each f32 sample contributes exactly one
+/// wire byte, so `samples.len()` must be a multiple of `2 * g` (stereo only;
+/// the shim hardcodes stereo).
+pub fn pack_wire_frames(samples: &[f32], channels: usize, out: &mut [u8]) {
+    if channels != 2 {
+        return;
+    }
+    let variant = SasWireVariant::from_code(wire_variant());
+    let group = wire_group_bytes();
+    let frame_samples = group * 2;
+    let wire_frames = samples.len() / frame_samples;
+    if out.len() < wire_frames * frame_samples {
+        return;
+    }
+    for (j, out_chunk) in out[..wire_frames * frame_samples]
+        .chunks_exact_mut(frame_samples)
+        .enumerate()
+    {
+        // samples: L0 R0 L1 R1 ... — per wire frame we consume g L + g R bytes.
+        let base = j * frame_samples;
+        let (l_slot, r_slot) = out_chunk.split_at_mut(group);
+        for k in 0..group {
+            let lb = (samples[base + k * 2].to_bits() & 0xFF) as u8;
+            let rb = (samples[base + k * 2 + 1].to_bits() & 0xFF) as u8;
+            let pos = if variant.byte_reversed() {
+                group - 1 - k
+            } else {
+                k
+            };
+            l_slot[pos] = if variant.bit_reversed() {
+                lb.reverse_bits()
+            } else {
+                lb
+            };
+            r_slot[pos] = if variant.bit_reversed() {
+                rb.reverse_bits()
+            } else {
+                rb
+            };
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+mod internal {
+    use std::ffi::{c_void, CString};
+    use std::sync::mpsc;
+    use std::sync::OnceLock;
+    use std::time::Duration;
+
+    const SHIM_LIB: &str = "libsmartaudioservice.so";
+    const FMT_TYPE_DSD: i32 = 6;
+    /// Per-attempt timeout for the probe write ladder. A drain-paced write
+    /// of the largest ladder size takes ~1.3 s, so 4 s has ample headroom.
+    const PROBE_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(4);
+    /// Write sizes probed in ascending order. The smallest size the
+    /// framework AudioTrack accepts fully (in one call) becomes the render
+    /// loop's write granularity. Rejected sizes return 0 immediately; each
+    /// retry also re-runs the shim's lazy track creation, which covers the
+    /// route-settling window after openOutput.
+    const PROBE_LADDER: [usize; 4] = [32_768 * 8, 65_536 * 8, 131_072 * 8, 262_144 * 8];
+    /// DSD silence: the SACD-convention 0x69 that stock's drain loop memsets
+    /// before stop (RE-verified in libhibyservice.so). DC-free per byte
+    /// (4 ones / 4 zeros).
+    const DSD_SILENCE_BYTE: u8 = 0x69;
+
+    type CreateTrackFn = unsafe extern "C" fn(i32, i32, i32, i32) -> *mut c_void;
+    type ReleaseTrackFn = unsafe extern "C" fn(*mut c_void);
+    type SlotStartFn = unsafe extern "C" fn(*mut c_void);
+    type SlotWriteFn = unsafe extern "C" fn(*mut c_void, *const u8, usize) -> i32;
+    type SlotFlushFn = unsafe extern "C" fn(*mut c_void);
+    type SlotTeardownFn = unsafe extern "C" fn(*mut c_void);
+    type SlotStoppedFn = unsafe extern "C" fn(*mut c_void) -> i32;
+
+    struct ShimFns {
+        create_track: CreateTrackFn,
+        release_track: ReleaseTrackFn,
+    }
+
+    static SHIM: OnceLock<Result<ShimFns, String>> = OnceLock::new();
+
+    fn shim() -> &'static Result<ShimFns, String> {
+        SHIM.get_or_init(|| {
+            // Public library: loadable from the app namespace (same SELinux
+            // domain HiBy Music uses, so this cannot be policy-blocked).
+            let name = CString::new(SHIM_LIB).unwrap();
+            // Clear any stale dlerror state first.
+            unsafe { libc::dlerror() };
+            let handle = unsafe { libc::dlopen(name.as_ptr(), libc::RTLD_NOW) };
+            if handle.is_null() {
+                let err = unsafe {
+                    let msg = libc::dlerror();
+                    if msg.is_null() {
+                        "unknown dlopen error".to_string()
+                    } else {
+                        std::ffi::CStr::from_ptr(msg).to_string_lossy().into_owned()
+                    }
+                };
+                return Err(format!("dlopen {}: {}", SHIM_LIB, err));
+            }
+            macro_rules! dlsym {
+                ($name:expr, $ty:ty) => {{
+                    let sym = CString::new($name).unwrap();
+                    let ptr = unsafe { libc::dlsym(handle, sym.as_ptr()) };
+                    if ptr.is_null() {
+                        return Err(format!("dlsym {} failed", $name));
+                    }
+                    unsafe { std::mem::transmute::<*mut c_void, $ty>(ptr) }
+                }};
+            }
+            let create_track = dlsym!("create_track", CreateTrackFn);
+            let release_track = dlsym!("release_track", ReleaseTrackFn);
+            Ok(ShimFns {
+                create_track,
+                release_track,
+            })
+        })
+    }
+
+    /// Cheap availability check: dlopen + symbol resolution only. Creates no
+    /// AudioTrack; real validation happens in `create_dsd_track`.
+    pub fn probe_unavailable_reason() -> Option<String> {
+        match shim() {
+            Ok(_) => None,
+            Err(reason) => Some(reason.clone()),
+        }
+    }
+
+    pub struct SasTrack {
+        obj: *mut c_void,
+        release_track: ReleaseTrackFn,
+        slot_write: SlotWriteFn,
+        slot_flush: SlotFlushFn,
+        slot_teardown: SlotTeardownFn,
+        slot_stopped: SlotStoppedFn,
+        bit_rate: u32,
+        /// Probe-verified write granularity in bytes (accepted by the
+        /// framework AudioTrack in a single call).
+        write_size: usize,
+    }
+
+    unsafe impl Send for SasTrack {}
+
+    impl SasTrack {
+        pub fn bit_rate(&self) -> u32 {
+            self.bit_rate
+        }
+
+        pub fn wire_rate(&self) -> u32 {
+            wire_rate_for(self.bit_rate)
+        }
+
+        pub fn write_size(&self) -> usize {
+            self.write_size
+        }
+
+        /// Blocking write of packed wire frames. Returns bytes written
+        /// (== `data.len()`) or a value <= 0 on failure.
+        pub fn write(&self, data: &[u8]) -> i32 {
+            if data.is_empty() {
+                return 0;
+            }
+            unsafe { (self.slot_write)(self.obj, data.as_ptr(), data.len()) }
+        }
+
+        pub fn flush(&self) {
+            unsafe { (self.slot_flush)(self.obj) }
+        }
+
+        /// Stop + release the framework tracks; the shim object stays usable
+        /// (its write re-creates the AudioTrack lazily).
+        pub fn teardown(&self) {
+            unsafe { (self.slot_teardown)(self.obj) }
+        }
+
+        /// Slot 0x28 returns 1 while the track is alive
+        /// (`track ? !AudioTrack::stopped() : status != 4`).
+        pub fn stopped(&self) -> bool {
+            unsafe { (self.slot_stopped)(self.obj) == 0 }
+        }
+
+        /// Final cleanup: frees the shim object and ctx. Consumes self.
+        pub fn release(self) {
+            self.teardown();
+            unsafe { (self.release_track)(self.obj) };
+        }
+    }
+
+    pub fn wire_rate_for(bit_rate: u32) -> u32 {
+        bit_rate / 32
+    }
+
+    /// Creates a DSD offload track and verifies it can actually take data:
+    /// `create_track` returns the vtable object even when the framework
+    /// AudioTrack failed to initialize (its write lazily re-creates the
+    /// track and returns 0 while no track exists), so the probe starts the
+    /// track and runs a write-size ladder under a watchdog. Each ladder
+    /// write re-runs the lazy creation, which also covers the output route
+    /// settling window. The probe thread owns the object until a full write
+    /// succeeds; on failure or timeout it tears everything down itself.
+    pub fn create_dsd_track(bit_rate: u32) -> Result<SasTrack, String> {
+        let shim = shim().as_ref().map_err(|e| e.clone())?;
+
+        if bit_rate % 32 != 0 || bit_rate < 282_240 {
+            return Err(format!("invalid DSD bit rate {}", bit_rate));
+        }
+
+        // Stock-exact args (logcat on the R4 with HiBy Music, DSD128):
+        // create_track(5644800, 2, 6, 1).
+        let obj = unsafe { (shim.create_track)(bit_rate as i32, 2, FMT_TYPE_DSD, 1) };
+        if obj.is_null() {
+            return Err("sas create_track returned null (OOM)".to_string());
+        }
+
+        let slot = |offset: usize| unsafe {
+            *((obj as *const u8 as *const *mut c_void).add(offset / 8))
+        };
+        // Vtable layout (PLT stubs resolved from the shim binary):
+        // [0x00] write, [0x08] soft stop, [0x10] teardown (stop + release
+        // track object), [0x18] start, [0x20] flush, [0x28] stopped,
+        // [0x30] latency, [0x38] get_rate, [0x40] get_channels, [0x50] ctx.
+        let slot_start: SlotStartFn =
+            unsafe { std::mem::transmute::<*mut c_void, SlotStartFn>(slot(0x18)) };
+        let slot_write: SlotWriteFn =
+            unsafe { std::mem::transmute::<*mut c_void, SlotWriteFn>(slot(0x00)) };
+        let slot_flush: SlotFlushFn =
+            unsafe { std::mem::transmute::<*mut c_void, SlotFlushFn>(slot(0x20)) };
+        let slot_teardown: SlotTeardownFn =
+            unsafe { std::mem::transmute::<*mut c_void, SlotTeardownFn>(slot(0x10)) };
+        let slot_stopped: SlotStoppedFn =
+            unsafe { std::mem::transmute::<*mut c_void, SlotStoppedFn>(slot(0x28)) };
+
+        // Introspection: read the framework AudioTrack members through the
+        // shim ctx to see exactly what the HAL negotiated (offsets from the
+        // R4's HiBy-patched libaudioclient.so: 0xa8 mTransfer, 0x208
+        // mFrameSize, 0x210 mStatus, 0x348 isDirect).
+        unsafe fn log_track_internals(obj: *mut c_void, phase: &str) {
+            let obj_bytes = obj as *const u8;
+            let ctx = *((obj_bytes).add(0x50) as *const *const u8);
+            if ctx.is_null() {
+                log::info!("[DSD-SAS] {}: shim ctx is null", phase);
+                return;
+            }
+            let ctx_bytes = ctx as *const u8;
+            let track = *(ctx_bytes.add(0x8) as *const *const u8);
+            if track.is_null() {
+                log::info!(
+                    "[DSD-SAS] {}: framework track NOT created (lazy creation pending or failed)",
+                    phase
+                );
+                return;
+            }
+            let tb = track as *const u8;
+            let transfer = *(tb.add(0xa8) as *const u32);
+            let frame_size = *(tb.add(0x208) as *const u64);
+            let status = *(tb.add(0x210) as *const u32);
+            let direct = *(tb.add(0x348) as *const u32);
+            log::info!(
+                "[DSD-SAS] {}: track={:p} transfer={} frameSize={} status={} direct={}",
+                phase,
+                track,
+                transfer,
+                frame_size,
+                status,
+                direct
+            );
+        }
+
+        unsafe { log_track_internals(obj, "after create_track") };
+        unsafe { slot_start(obj) };
+        unsafe { log_track_internals(obj, "after start") };
+
+        let probe_buf = vec![DSD_SILENCE_BYTE; *PROBE_LADDER.last().unwrap()];
+
+        let (tx, rx) = mpsc::channel::<(usize, i32)>();
+        // Raw pointers are not Send; pass the shim object as an address.
+        let thread_obj_addr = obj as usize;
+        let thread_release = shim.release_track;
+        std::thread::Builder::new()
+            .name("dsd-sas-probe".to_string())
+            .spawn(move || {
+                let thread_obj = thread_obj_addr as *mut c_void;
+                // This thread owns obj until a full write succeeds; on any
+                // failure (or a timeout abandon by the main thread) it tears
+                // down and releases the track itself.
+                let mut success = false;
+                for &size in PROBE_LADDER.iter() {
+                    let written = unsafe { slot_write(thread_obj, probe_buf.as_ptr(), size) };
+                    log::info!("[DSD-SAS] probe write({} B) -> {}", size, written);
+                    let full = written > 0 && written as usize == size;
+                    if tx.send((size, written)).is_err() {
+                        // Main thread gave up: clean up and stop.
+                        unsafe { slot_teardown(thread_obj) };
+                        unsafe { thread_release(thread_obj) };
+                        return;
+                    }
+                    if full {
+                        success = true;
+                        break;
+                    }
+                    if written < 0 {
+                        break;
+                    }
+                }
+                if !success {
+                    unsafe { slot_teardown(thread_obj) };
+                    unsafe { thread_release(thread_obj) };
+                }
+            })
+            .map_err(|e| {
+                unsafe { slot_teardown(obj) };
+                unsafe { (shim.release_track)(obj) };
+                format!("failed to spawn probe thread: {}", e)
+            })?;
+
+        let mut write_size: usize = 0;
+        let mut last: Option<(usize, i32)> = None;
+        loop {
+            match rx.recv_timeout(PROBE_ATTEMPT_TIMEOUT) {
+                Ok((size, written)) => {
+                    if written > 0 && written as usize == size {
+                        write_size = size;
+                        break;
+                    }
+                    last = Some((size, written));
+                    if written < 0 {
+                        break;
+                    }
+                }
+                // Timeout or ladder exhausted (channel closed).
+                Err(_) => break,
+            }
+        }
+
+        if write_size > 0 {
+            // Drop the probe silence so it never plays; hand obj back.
+            unsafe { slot_flush(obj) };
+            log::info!(
+                "[DSD-SAS] DSD offload track verified: bit_rate={} Hz, wire {} Hz, write granularity {} B",
+                bit_rate,
+                wire_rate_for(bit_rate),
+                write_size
+            );
+            Ok(SasTrack {
+                obj,
+                release_track: shim.release_track,
+                slot_write,
+                slot_flush,
+                slot_teardown,
+                slot_stopped,
+                bit_rate,
+                write_size,
+            })
+        } else {
+            let (size, written) = last.unwrap_or((0, 0));
+            Err(format!(
+                "sas DSD write rejected: {} B write returned {} (no DSD output route)",
+                size, written
+            ))
+        }
+    }
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "android")]
+pub use internal::{create_dsd_track, probe_unavailable_reason, wire_rate_for, SasTrack};
+
+#[cfg(target_os = "android")]
+pub fn probe_available() -> bool {
+    internal::probe_unavailable_reason().is_none()
+}
+
+#[cfg(not(target_os = "android"))]
+pub fn probe_available() -> bool {
+    false
+}
+
+#[cfg(not(target_os = "android"))]
+pub fn probe_unavailable_reason() -> Option<String> {
+    Some("SAS shim is Android-only".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// pack_wire_frames reads process-global atomics; serialize the tests
+    /// that flip them.
+    static PACKER_LOCK: Mutex<()> = Mutex::new(());
+
+    fn dsd_sample(byte: u8) -> f32 {
+        f32::from_bits(byte as u32)
+    }
+
+    fn interleave(l: [u8; 4], r: [u8; 4]) -> Vec<f32> {
+        let mut v = Vec::with_capacity(8);
+        for i in 0..4 {
+            v.push(dsd_sample(l[i]));
+            v.push(dsd_sample(r[i]));
+        }
+        v
+    }
+
+    #[test]
+    fn wire_groupings_pack_expected_layouts() {
+        let _guard = PACKER_LOCK.lock().unwrap();
+        // Raw DSD byte streams: L = 01..04, R = 11..14 (hex), interleaved.
+        let samples = interleave([0x01, 0x02, 0x03, 0x04], [0x11, 0x12, 0x13, 0x14]);
+
+        // U32 (legacy): 8-byte frames, 4 L bytes then 4 R bytes.
+        set_wire_grouping(0);
+        set_wire_variant(0);
+        let mut out = [0u8; 8];
+        pack_wire_frames(&samples, 2, &mut out);
+        assert_eq!(
+            &out,
+            &[0x01, 0x02, 0x03, 0x04, 0x11, 0x12, 0x13, 0x14][..]
+        );
+
+        // U16: 4-byte frames, 2 L bytes then 2 R bytes.
+        set_wire_grouping(1);
+        let mut out = [0u8; 8];
+        pack_wire_frames(&samples, 2, &mut out);
+        assert_eq!(&out, &[0x01, 0x02, 0x11, 0x12, 0x03, 0x04, 0x13, 0x14][..]);
+
+        // U8: plain byte interleave, wire order == sample order.
+        set_wire_grouping(2);
+        let mut out = [0u8; 8];
+        pack_wire_frames(&samples, 2, &mut out);
+        assert_eq!(
+            &out,
+            &[0x01, 0x11, 0x02, 0x12, 0x03, 0x13, 0x04, 0x14][..]
+        );
+
+        set_wire_grouping(2);
+    }
+
+    #[test]
+    fn variants_transform_subslots() {
+        let _guard = PACKER_LOCK.lock().unwrap();
+        // Raw DSD byte streams: L = 01..04, R = 11..14 (hex).
+        let raw: [u8; 8] = [0x01, 0x02, 0x03, 0x04, 0x11, 0x12, 0x13, 0x14];
+        let samples = interleave(
+            [raw[0], raw[1], raw[2], raw[3]],
+            [raw[4], raw[5], raw[6], raw[7]],
+        );
+
+        let mut out = [0u8; 8];
+        set_wire_grouping(0); // 32-bit subslots for this test
+        for (code, (swap, bitrev)) in [
+            (0u8, (false, false)),
+            (1, (true, false)),
+            (2, (false, true)),
+            (3, (true, true)),
+        ] {
+            set_wire_variant(code);
+            pack_wire_frames(&samples, 2, &mut out);
+            let expected: Vec<u8> = (0..8)
+                .map(|i| {
+                    let sub = i / 4; // 0 = L subslot, 1 = R subslot
+                    let k = i % 4;
+                    let pos = if swap { 3 - k } else { k };
+                    let byte = raw[sub * 4 + pos];
+                    if bitrev {
+                        byte.reverse_bits()
+                    } else {
+                        byte
+                    }
+                })
+                .collect();
+            assert_eq!(&out[..], &expected[..], "variant {}", code);
+        }
+        set_wire_variant(0);
+        set_wire_grouping(2);
+    }
+
+    #[test]
+    fn silence_is_dc_free() {
+        // 0x69 = SACD silence byte (what stock memsets before stop);
+        // 4 ones / 4 zeros per byte, DC-free in either bit order.
+        assert_eq!(0x69u8.count_ones(), 4);
+        assert_eq!(0x69u8.reverse_bits(), 0x96);
+        assert_eq!(0x96u8.count_ones(), 4);
+    }
+
+    #[test]
+    fn non_android_stub_unavailable() {
+        #[cfg(not(target_os = "android"))]
+        {
+            assert!(!probe_available());
+            assert!(probe_unavailable_reason().is_some());
+        }
+    }
+}

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -3595,7 +3595,7 @@ fn command_processing_loop(
                         callback_data.pitch_shifter.lock().reset();
                     }
                     AudioCommand::SetVolume { volume } => {
-                        callback_data.set_volume(volume.clamp(0.0, 1.0));
+                        callback_data.set_volume(volume.clamp(0.0, MAX_VOLUME));
                     }
                     AudioCommand::SetReplayGain { gain_db } => {
                         // Store the default for spawns (next track, seek

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -210,6 +210,18 @@ pub struct AudioCallbackData {
     /// the stream so playback resumes at the interrupted position instead of
     /// jumping to another time.
     stream_needs_restart: AtomicBool,
+    /// Native-DSD transport active: silence fills emit the SACD silence byte
+    /// 0x69 (a 0.0 f32 packs to wire 0x00 = DC = pops).
+    dsd_wire_silence: AtomicBool,
+    /// DoP transport active: silence fills carry 0x05/0xFA marker framing
+    /// (zero words desync the DAC's marker detector and click).
+    dop_wire_silence: AtomicBool,
+    /// Phase for the alternating 0x05/0xFA DoP silence marker.
+    dop_marker_phase: AtomicBool,
+    /// Telemetry: DSD silence samples injected due to short ring reads.
+    dsd_starved_samples: AtomicU64,
+    /// Telemetry: callbacks silenced by `sources` lock contention.
+    dsd_lock_misses: AtomicU64,
 }
 
 impl AudioCallbackData {
@@ -263,7 +275,70 @@ impl AudioCallbackData {
             crossfade_forces_dsp: AtomicBool::new(false),
             crossfade_active: AtomicBool::new(false),
             stream_needs_restart: AtomicBool::new(false),
+            dsd_wire_silence: AtomicBool::new(false),
+            dop_wire_silence: AtomicBool::new(false),
+            dop_marker_phase: AtomicBool::new(false),
+            dsd_starved_samples: AtomicU64::new(0),
+            dsd_lock_misses: AtomicU64::new(0),
         }
+    }
+
+    /// Managed by the DSD native backend around its render thread (see
+    /// [Self::fill_silence]).
+    #[inline]
+    pub(crate) fn set_dsd_wire_silence(&self, enabled: bool) {
+        self.dsd_wire_silence.store(enabled, Ordering::Relaxed);
+    }
+
+    /// Managed around DoP render loops (see [Self::fill_silence]).
+    #[inline]
+    pub(crate) fn set_dop_wire_silence(&self, enabled: bool) {
+        self.dop_wire_silence.store(enabled, Ordering::Relaxed);
+    }
+
+    /// Transport-appropriate silence: DSD wire gets byte 0x69 (0.0 packs to
+    /// DC and pops), DoP wire gets marker-framed words, PCM gets 0.0.
+    #[inline]
+    pub(crate) fn fill_silence(&self, output: &mut [f32]) {
+        if self.dsd_wire_silence.load(Ordering::Relaxed) {
+            output.fill(f32::from_bits(0x69));
+        } else if self.dop_wire_silence.load(Ordering::Relaxed) {
+            let mut marker_is_fa = self.dop_marker_phase.load(Ordering::Relaxed);
+            for sample in output.iter_mut() {
+                let marker = if marker_is_fa { 0xFA } else { 0x05 };
+                *sample = f32::from_bits((marker as u32) << 24 | 0x69 << 16 | 0x96 << 8);
+                marker_is_fa = !marker_is_fa;
+            }
+            self.dop_marker_phase.store(marker_is_fa, Ordering::Relaxed);
+        } else {
+            output.fill(0.0);
+        }
+    }
+
+    /// try_lock for `sources` that yield-retries briefly — a plain miss in
+    /// the RT callback would silence a whole DSD chunk = audible pop.
+    pub(crate) fn lock_sources_rt(
+        &self,
+    ) -> Option<parking_lot::MutexGuard<'_, SourceProvider>> {
+        for attempt in 0..64 {
+            if let Some(guard) = self.sources.try_lock() {
+                return Some(guard);
+            }
+            if attempt < 63 {
+                std::thread::yield_now();
+            }
+        }
+        None
+    }
+
+    /// (starved samples, lock misses) telemetry snapshot for the DSD render
+    /// loop's warn-on-change logging.
+    #[allow(dead_code)] // consumed by the Android-only SAS render loop
+    pub(crate) fn dsd_starve_stats(&self) -> (u64, u64) {
+        (
+            self.dsd_starved_samples.load(Ordering::Relaxed),
+            self.dsd_lock_misses.load(Ordering::Relaxed),
+        )
     }
 
     #[inline]
@@ -1101,7 +1176,9 @@ fn build_output_runtime_state(
     let (dsd_wire_rate, dsd_transport) = if dsd_source_rate.is_some() {
         let wire_rate = verification.actual_rate;
         let transport = match strategy {
-            OutputStrategy::DsdNative => "dap-native-alsa".to_string(),
+            OutputStrategy::DsdNative => {
+                crate::audio::dsd_sas_shim::native_transport_name().to_string()
+            }
             OutputStrategy::UsbDsdNative => {
                 #[cfg(feature = "uac2")]
                 {
@@ -1804,8 +1881,9 @@ pub fn create_audio_engine(
                 log::info!(
                     "[ENGINE] DSD Native backend created at {} Hz (via {})",
                     requested_sample_rate,
-                    if backend.is_alsa() { "ALSA direct" } else { "ENCODING_DSD" }
+                    backend.transport_name()
                 );
+                crate::api::audio_api::clear_dsd_native_failure();
                 final_sample_rate = requested_sample_rate;
                 callback_data.reconfigure_sample_rate(final_sample_rate);
                 callback_data.set_pipeline_mode(PipelineMode::Dop);
@@ -2027,10 +2105,13 @@ pub fn create_audio_engine(
             && effective_dsd_mode == crate::audio::dsd_engine::dsd::DsdOutputMode::Dop
             && dsd_native_backend.is_none()
         {
-            output_runtime.verification_reason = Some(
-                "DoP active (bit-perfect DSD). Native DSD unavailable on this device."
-                    .to_string(),
-            );
+            let native_failure_note = crate::api::audio_api::last_dsd_native_failure()
+                .map(|reason| format!(" Native attempt failed: {}.", reason))
+                .unwrap_or_default();
+            output_runtime.verification_reason = Some(format!(
+                "DoP active (bit-perfect DSD). Native DSD unavailable on this device.{}",
+                native_failure_note
+            ));
         }
         // Verified-exclusive DapNative rides the HAL direct_pcm profile
         // (mixer bypass); give it its own signature so reuse + diagnostics
@@ -3131,16 +3212,17 @@ pub(crate) fn audio_callback(
     _event_tx: &Sender<AudioEvent>,
 ) {
     if data.is_paused() {
-        output.fill(0.0);
+        data.fill_silence(output);
         return;
     }
 
     // Passthrough path: raw samples from decoder straight to output.
     if data.pipeline_mode.load(Ordering::Relaxed) == PipelineMode::Dop as u8 {
-        let mut sources = match data.sources.try_lock() {
+        let mut sources = match data.lock_sources_rt() {
             Some(s) => s,
             None => {
-                output.fill(0.0);
+                data.dsd_lock_misses.fetch_add(1, Ordering::Relaxed);
+                data.fill_silence(output);
                 return;
             }
         };
@@ -3149,7 +3231,9 @@ pub(crate) fn audio_callback(
             let _ = data.finished_tracks.try_send(source);
         }
         if read < output.len() {
-            output[read..].fill(0.0);
+            data.dsd_starved_samples
+                .fetch_add((output.len() - read) as u64, Ordering::Relaxed);
+            data.fill_silence(&mut output[read..]);
         }
         return;
     }
@@ -3159,10 +3243,11 @@ pub(crate) fn audio_callback(
     // hardware volume) is the only volume authority. Software gain would
     // corrupt the stream.
     if data.is_passthrough() {
-        let mut sources = match data.sources.try_lock() {
+        let mut sources = match data.lock_sources_rt() {
             Some(s) => s,
             None => {
-                output.fill(0.0);
+                data.dsd_lock_misses.fetch_add(1, Ordering::Relaxed);
+                data.fill_silence(output);
                 return;
             }
         };
@@ -3172,7 +3257,9 @@ pub(crate) fn audio_callback(
             let _ = data.finished_tracks.try_send(source);
         }
         if read < output.len() {
-            output[read..].fill(0.0);
+            data.dsd_starved_samples
+                .fetch_add((output.len() - read) as u64, Ordering::Relaxed);
+            data.fill_silence(&mut output[read..]);
         }
         return;
     }
@@ -3648,9 +3735,11 @@ fn command_processing_loop(
                             callback_data
                                 .pipeline_mode
                                 .store(PipelineMode::Dop as u8, Ordering::Relaxed);
+                            callback_data.set_dop_wire_silence(true);
                         } else {
                             let base = callback_data.base_pipeline_mode.load(Ordering::Relaxed);
                             callback_data.pipeline_mode.store(base, Ordering::Relaxed);
+                            callback_data.set_dop_wire_silence(false);
                         }
                     }
                     AudioCommand::SetFx {
@@ -4161,6 +4250,21 @@ mod tests {
         let mut output = vec![123.0; output_len];
         audio_callback(&mut output, data, &event_tx);
         output
+    }
+
+    #[test]
+    fn dsd_wire_silence_fills_with_silence_byte() {
+        let data = build_passthrough_callback_data(705_600, 2);
+
+        // DSD wire must get 0x69, not 0.0 (packs to DC = pop).
+        data.set_dsd_wire_silence(true);
+        let output = run_callback(&data, 16);
+        assert!(output.iter().all(|s| (s.to_bits() & 0xFF) == 0x69));
+
+        // PCM outputs keep true zero silence.
+        data.set_dsd_wire_silence(false);
+        let output = run_callback(&data, 16);
+        assert!(output.iter().all(|s| s.to_bits() == 0));
     }
 
     #[test]

--- a/rust/src/audio/mod.rs
+++ b/rust/src/audio/mod.rs
@@ -24,6 +24,7 @@ pub mod decoder_handle;
 pub mod device;
 pub mod dsd_alsa_direct;
 pub mod dsd_engine;
+pub mod dsd_sas_shim;
 pub mod dsd_native_backend;
 pub mod dsd_native_jni;
 pub mod dynamics;

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 396510651;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1865297264;
 
 // Section: executor
 
@@ -1973,6 +1973,70 @@ fn wire__crate__api__audio_api__audio_set_replaygain_default_impl(
         },
     )
 }
+fn wire__crate__api__audio_api__audio_set_sas_wire_grouping_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "audio_set_sas_wire_grouping",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_grouping = <u8>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::audio_api::audio_set_sas_wire_grouping(api_grouping);
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__audio_api__audio_set_sas_wire_variant_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "audio_set_sas_wire_variant",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_variant = <u8>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::audio_api::audio_set_sas_wire_variant(api_variant);
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__audio_api__audio_set_volume_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -2137,6 +2201,40 @@ fn wire__crate__api__scanner__check_deleted_paths_impl(
                         api_known_files,
                         api_scan_options,
                     ))?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__audio_api__clear_dsd_native_failure_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "clear_dsd_native_failure",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok({
+                        crate::api::audio_api::clear_dsd_native_failure();
+                    })?;
                     Ok(output_ok)
                 })())
             }
@@ -2486,6 +2584,39 @@ fn wire__crate__api__simple__init_app_impl(
                     let output_ok = Result::<_, ()>::Ok({
                         crate::api::simple::init_app();
                     })?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__audio_api__last_dsd_native_failure_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "last_dsd_native_failure",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok =
+                        Result::<_, ()>::Ok(crate::api::audio_api::last_dsd_native_failure())?;
                     Ok(output_ok)
                 })())
             }
@@ -5303,191 +5434,203 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        59 => wire__crate__api__audio_api__audio_set_volume_impl(port, ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__audio_api__audio_shutdown_impl(port, ptr, rust_vec_len, data_len),
-        61 => {
+        61 => wire__crate__api__audio_api__audio_set_volume_impl(port, ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__audio_api__audio_shutdown_impl(port, ptr, rust_vec_len, data_len),
+        63 => {
             wire__crate__api__audio_api__audio_skip_to_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        62 => wire__crate__api__audio_api__audio_stop_impl(port, ptr, rust_vec_len, data_len),
-        63 => {
+        64 => wire__crate__api__audio_api__audio_stop_impl(port, ptr, rust_vec_len, data_len),
+        65 => {
             wire__crate__api__scanner__check_deleted_paths_impl(port, ptr, rust_vec_len, data_len)
         }
-        64 => wire__crate__api__audio_api__clear_dsd_track_rate_impl(
+        66 => wire__crate__api__audio_api__clear_dsd_native_failure_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        65 => wire__crate__api__audio_api__current_dsd_output_mode_impl(
+        67 => wire__crate__api__audio_api__clear_dsd_track_rate_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        66 => wire__crate__api__audio_api__current_dsd_track_rate_impl(
+        68 => wire__crate__api__audio_api__current_dsd_output_mode_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        67 => wire__crate__api__scanner__discover_playlist_files_impl(
+        69 => wire__crate__api__audio_api__current_dsd_track_rate_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        68 => wire__crate__api__audio_api__effective_dsd_output_mode_impl(
+        70 => wire__crate__api__scanner__discover_playlist_files_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        69 => wire__crate__api__audio_api__effective_dsd_output_mode_for_rate_impl(
+        71 => wire__crate__api__audio_api__effective_dsd_output_mode_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        70 => wire__crate__api__scanner__extract_embedded_artwork_impl(
+        72 => wire__crate__api__audio_api__effective_dsd_output_mode_for_rate_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        71 => {
+        73 => wire__crate__api__scanner__extract_embedded_artwork_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        74 => {
             wire__crate__api__scanner__extract_file_metadata_impl(port, ptr, rust_vec_len, data_len)
         }
-        73 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        74 => wire__crate__api__audio_api__last_volume_impl(port, ptr, rust_vec_len, data_len),
-        75 => wire__crate__api__replaygain__read_replaygain_tags_impl(
+        76 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        77 => wire__crate__api__audio_api__last_dsd_native_failure_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        76 => wire__crate__api__metadata_editor__read_tags_impl(port, ptr, rust_vec_len, data_len),
-        77 => wire__crate__api__logging__register_log_sink_impl(port, ptr, rust_vec_len, data_len),
-        78 => wire__crate__api__scanner__scan_music_library_impl(port, ptr, rust_vec_len, data_len),
-        79 => wire__crate__api__scanner__scan_root_dir_impl(port, ptr, rust_vec_len, data_len),
-        80 => {
+        78 => wire__crate__api__audio_api__last_volume_impl(port, ptr, rust_vec_len, data_len),
+        79 => wire__crate__api__replaygain__read_replaygain_tags_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        80 => wire__crate__api__metadata_editor__read_tags_impl(port, ptr, rust_vec_len, data_len),
+        81 => wire__crate__api__logging__register_log_sink_impl(port, ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__scanner__scan_music_library_impl(port, ptr, rust_vec_len, data_len),
+        83 => wire__crate__api__scanner__scan_root_dir_impl(port, ptr, rust_vec_len, data_len),
+        84 => {
             wire__crate__api__audio_api__set_dsd_track_rate_impl(port, ptr, rust_vec_len, data_len)
         }
-        81 => wire__crate__api__audio_api__set_pending_crossfade_impl(
+        85 => wire__crate__api__audio_api__set_pending_crossfade_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        82 => wire__crate__api__audio_api__set_pending_crossfade_curve_impl(
+        86 => wire__crate__api__audio_api__set_pending_crossfade_curve_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        83 => wire__crate__api__audio_api__set_pending_crossfeed_impl(
+        87 => wire__crate__api__audio_api__set_pending_crossfeed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        84 => wire__crate__api__audio_api__set_pending_equalizer_impl(
+        88 => wire__crate__api__audio_api__set_pending_equalizer_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        85 => {
+        89 => {
             wire__crate__api__audio_api__set_pending_volume_impl(port, ptr, rust_vec_len, data_len)
         }
-        86 => wire__crate__api__smb_api__smb_download_file_impl(port, ptr, rust_vec_len, data_len),
-        87 => wire__crate__api__smb_api__smb_list_share_impl(port, ptr, rust_vec_len, data_len),
-        88 => wire__crate__api__smb_api__smb_ping_impl(port, ptr, rust_vec_len, data_len),
-        89 => wire__crate__api__smb_api__smb_read_file_impl(port, ptr, rust_vec_len, data_len),
-        90 => wire__crate__api__audio_api__take_pending_crossfade_impl(
+        90 => wire__crate__api__smb_api__smb_download_file_impl(port, ptr, rust_vec_len, data_len),
+        91 => wire__crate__api__smb_api__smb_list_share_impl(port, ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__smb_api__smb_ping_impl(port, ptr, rust_vec_len, data_len),
+        93 => wire__crate__api__smb_api__smb_read_file_impl(port, ptr, rust_vec_len, data_len),
+        94 => wire__crate__api__audio_api__take_pending_crossfade_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        91 => wire__crate__api__audio_api__take_pending_crossfeed_impl(
+        95 => wire__crate__api__audio_api__take_pending_crossfeed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        92 => wire__crate__api__audio_api__take_pending_equalizer_impl(
+        96 => wire__crate__api__audio_api__take_pending_equalizer_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        93 => {
+        97 => {
             wire__crate__api__audio_api__take_pending_volume_impl(port, ptr, rust_vec_len, data_len)
         }
-        94 => wire__crate__api__uac2_api__uac2_activate_fallback_impl(
+        98 => wire__crate__api__uac2_api__uac2_activate_fallback_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        95 => wire__crate__api__uac2_api__uac2_attempt_reconnect_impl(
+        99 => wire__crate__api__uac2_api__uac2_attempt_reconnect_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        96 => wire__crate__api__uac2_api__uac2_deactivate_fallback_impl(
+        100 => wire__crate__api__uac2_api__uac2_deactivate_fallback_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        97 => wire__crate__api__uac2_api__uac2_disconnect_impl(port, ptr, rust_vec_len, data_len),
-        100 => wire__crate__api__uac2_api__uac2_get_device_capabilities_impl(
+        101 => wire__crate__api__uac2_api__uac2_disconnect_impl(port, ptr, rust_vec_len, data_len),
+        104 => wire__crate__api__uac2_api__uac2_get_device_capabilities_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        105 => wire__crate__api__uac2_api__uac2_get_volume_range_impl(
+        109 => wire__crate__api__uac2_api__uac2_get_volume_range_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        109 => {
+        113 => {
             wire__crate__api__uac2_api__uac2_select_device_impl(port, ptr, rust_vec_len, data_len)
         }
-        110 => wire__crate__api__uac2_api__uac2_set_auto_reconnect_impl(
+        114 => wire__crate__api__uac2_api__uac2_set_auto_reconnect_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        111 => wire__crate__api__uac2_api__uac2_set_mute_impl(port, ptr, rust_vec_len, data_len),
-        112 => wire__crate__api__uac2_api__uac2_set_sampling_frequency_impl(
+        115 => wire__crate__api__uac2_api__uac2_set_mute_impl(port, ptr, rust_vec_len, data_len),
+        116 => wire__crate__api__uac2_api__uac2_set_sampling_frequency_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        113 => wire__crate__api__uac2_api__uac2_set_volume_impl(port, ptr, rust_vec_len, data_len),
-        114 => {
+        117 => wire__crate__api__uac2_api__uac2_set_volume_impl(port, ptr, rust_vec_len, data_len),
+        118 => {
             wire__crate__api__uac2_api__uac2_start_streaming_impl(port, ptr, rust_vec_len, data_len)
         }
-        115 => {
+        119 => {
             wire__crate__api__uac2_api__uac2_stop_streaming_impl(port, ptr, rust_vec_len, data_len)
         }
-        116 => wire__crate__api__replaygain__write_replaygain_tags_impl(
+        120 => wire__crate__api__replaygain__write_replaygain_tags_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        117 => {
+        121 => {
             wire__crate__api__metadata_editor__write_tags_impl(port, ptr, rust_vec_len, data_len)
         }
-        118 => wire__crate__api__metadata_editor__write_tags_to_temp_impl(
+        122 => wire__crate__api__metadata_editor__write_tags_to_temp_impl(
             port,
             ptr,
             rust_vec_len,
@@ -5599,28 +5742,38 @@ fn pde_ffi_dispatcher_sync_impl(
             rust_vec_len,
             data_len,
         ),
-        72 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        98 => wire__crate__api__uac2_api__uac2_force_release_usb_session_impl(
+        59 => wire__crate__api__audio_api__audio_set_sas_wire_grouping_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        99 => {
+        60 => wire__crate__api__audio_api__audio_set_sas_wire_variant_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        75 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        102 => wire__crate__api__uac2_api__uac2_force_release_usb_session_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        103 => {
             wire__crate__api__uac2_api__uac2_get_connection_state_impl(ptr, rust_vec_len, data_len)
         }
-        101 => wire__crate__api__uac2_api__uac2_get_fallback_info_impl(ptr, rust_vec_len, data_len),
-        102 => wire__crate__api__uac2_api__uac2_get_mute_impl(ptr, rust_vec_len, data_len),
-        103 => wire__crate__api__uac2_api__uac2_get_sampling_frequency_impl(
+        105 => wire__crate__api__uac2_api__uac2_get_fallback_info_impl(ptr, rust_vec_len, data_len),
+        106 => wire__crate__api__uac2_api__uac2_get_mute_impl(ptr, rust_vec_len, data_len),
+        107 => wire__crate__api__uac2_api__uac2_get_sampling_frequency_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        104 => wire__crate__api__uac2_api__uac2_get_volume_impl(ptr, rust_vec_len, data_len),
-        106 => wire__crate__api__uac2_api__uac2_is_available_impl(ptr, rust_vec_len, data_len),
-        107 => {
+        108 => wire__crate__api__uac2_api__uac2_get_volume_impl(ptr, rust_vec_len, data_len),
+        110 => wire__crate__api__uac2_api__uac2_is_available_impl(ptr, rust_vec_len, data_len),
+        111 => {
             wire__crate__api__uac2_api__uac2_is_usb_session_active_impl(ptr, rust_vec_len, data_len)
         }
-        108 => wire__crate__api__uac2_api__uac2_list_devices_impl(ptr, rust_vec_len, data_len),
+        112 => wire__crate__api__uac2_api__uac2_list_devices_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -81,11 +81,30 @@ fn initialize_android_app_context<'local>(
 pub extern "system" fn JNI_OnLoad(_vm: JavaVM, _reserved: *mut c_void) -> jni::sys::jint {
     android_logger::init_once(
         android_logger::Config::default()
-            .with_max_level(log::LevelFilter::Off)
+            // Debug builds log Debug+; release keeps Info so DSD transport
+            // telemetry (starvation warns, SAS probe) reaches logcat.
+            .with_max_level(if cfg!(debug_assertions) {
+                log::LevelFilter::Debug
+            } else {
+                log::LevelFilter::Info
+            })
             .with_tag("RustUSB"),
     );
     jni::JNIVersion::V6.into()
 }
+
+/// FRB installs its own `android_logger` during `RustLib.init` and clobbers
+/// the max level, silencing our logs after boot. Call at audio API entry
+/// points to keep debug builds logging for the whole session.
+#[cfg(target_os = "android")]
+pub fn assert_android_debug_logging() {
+    if cfg!(debug_assertions) {
+        log::set_max_level(log::LevelFilter::Debug);
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+pub fn assert_android_debug_logging() {}
 
 #[cfg(target_os = "android")]
 #[no_mangle]
@@ -555,10 +574,12 @@ pub extern "system" fn Java_com_mossapps_flick_MainActivity_nativeSetRustDevelop
     enabled: jboolean,
 ) {
     DEVELOPER_MODE.store(enabled != 0, Ordering::Relaxed);
+    // Developer mode off still keeps Info: DSD starvation/SAS diagnostics
+    // must survive in release builds.
     let level = if enabled != 0 {
         log::LevelFilter::Debug
     } else {
-        log::LevelFilter::Off
+        log::LevelFilter::Info
     };
     log::set_max_level(level);
 }

--- a/rust/src/uac2/android_direct.rs
+++ b/rust/src/uac2/android_direct.rs
@@ -80,8 +80,8 @@ const FORMAT_TAG_DSD: u16 = 0x0008;
 const UAC2_REQUEST_GET_MIN: u8 = 0x82;
 const UAC2_REQUEST_GET_MAX: u8 = 0x83;
 const UAC2_REQUEST_GET_RES: u8 = 0x84;
-const UAC2_FEATURE_UNIT_MUTE_CONTROL: u16 = 0x0101;
-const UAC2_FEATURE_UNIT_VOLUME_CONTROL: u16 = 0x0100;
+const UAC2_FEATURE_UNIT_MUTE_CONTROL: u16 = 0x0100;
+const UAC2_FEATURE_UNIT_VOLUME_CONTROL: u16 = 0x0200;
 const FEATURE_MUTE: u32 = 0x0001;
 const FEATURE_VOLUME: u32 = 0x0002;
 const ISO_TRANSFER_TIMEOUT_MS: u32 = 1000;
@@ -971,7 +971,12 @@ impl AndroidDirectUsbPcmRingBuffer {
         writable
     }
 
-    fn pop_into_or_pad(&mut self, output: &mut [i32], _channels: usize) -> bool {
+    fn pop_into_or_pad(
+        &mut self,
+        output: &mut [i32],
+        _channels: usize,
+        dsd_transport: DsdTransportMode,
+    ) -> bool {
         if output.is_empty() {
             return false;
         }
@@ -985,8 +990,25 @@ impl AndroidDirectUsbPcmRingBuffer {
 
         let underrun = readable < output.len();
         if underrun {
-            for sample in output[readable..].iter_mut() {
-                *sample = 0;
+            // Zero is full-scale DC for native DSD and breaks DoP marker sync;
+            // pad with a silent but valid bitstream instead.
+            for (offset, sample) in output[readable..].iter_mut().enumerate() {
+                let index = readable + offset;
+                *sample = match dsd_transport {
+                    DsdTransportMode::Native => {
+                        if index % 2 == 0 { 0x55 } else { 0xAA }
+                    }
+                    DsdTransportMode::DoP => {
+                        let marker = if index % 2 == 0 { 0x05 } else { 0xFA };
+                        let (b0, b1) = if index % 2 == 0 {
+                            (0x55, 0xAA)
+                        } else {
+                            (0xAA, 0x55)
+                        };
+                        ((marker as i32) << 24) | ((b0 as i32) << 16) | ((b1 as i32) << 8)
+                    }
+                    DsdTransportMode::None => 0,
+                };
             }
         }
 
@@ -1787,6 +1809,18 @@ pub fn negotiate_android_direct_output_sample_rate(
         };
         if let Some(rate) = preferred_sample_rate {
             requested_format.sample_rate = rate.max(8_000);
+            // A caller-supplied rate is a PCM request: don't inherit DSD
+            // transport flags or the engine keeps claiming the DSD alt
+            // setting. DSD modes re-stamp these at engine create.
+            if requested_format.is_dop || requested_format.dsd_transport != DsdTransportMode::None
+            {
+                requested_format.is_dop = false;
+                requested_format.dsd_transport = DsdTransportMode::None;
+                requested_format.dsd_bit_rate = 0;
+                if requested_format.bit_depth == 1 {
+                    requested_format.bit_depth = 24;
+                }
+            }
         }
 
         if state.stream_active || USB_SESSION_ACTIVE.load(Ordering::SeqCst) {
@@ -4594,6 +4628,14 @@ fn run_usb_render_loop(
     let mut logged_render_preview = false;
     let chunk_deadline = Duration::from_millis(ANDROID_USB_RENDER_CHUNK_MS as u64);
 
+    // Starvation fills must match the wire format: 0x00 bytes are DC on a
+    // native DSD wire and zero words break DoP marker sync.
+    if playback_format.is_dop {
+        callback_data.set_dop_wire_silence(true);
+    } else if playback_format.dsd_transport == DsdTransportMode::Native {
+        callback_data.set_dsd_wire_silence(true);
+    }
+
     while !usb_stop_requested(&stop) {
         let cycle_start = Instant::now();
         let buffered_samples = {
@@ -4787,6 +4829,9 @@ fn run_usb_render_loop(
             thread::sleep(Duration::from_millis(ANDROID_USB_RENDER_POLL_MS));
         }
     }
+
+    callback_data.set_dop_wire_silence(false);
+    callback_data.set_dsd_wire_silence(false);
 }
 
 fn prepare_iso_transfer_payload(
@@ -4835,7 +4880,7 @@ fn prepare_iso_transfer_payload(
     let mut packet_samples = vec![0i32; total_samples];
     let underrun = {
         let mut guard = pcm_buffer.lock();
-        let underrun = guard.pop_into_or_pad(&mut packet_samples, channels);
+        let underrun = guard.pop_into_or_pad(&mut packet_samples, channels, dsd_transport);
         runtime_stats
             .buffered_samples
             .store(guard.len_samples(), Ordering::Relaxed);


### PR DESCRIPTION
# Summary

- Add DSD-NATIVE output transport on Android via HiBy SAS offload shim (`libsmartaudioservice.so`) with direct ALSA fallback
- Add DSD wire format settings (bit order BE/LE × MSB/LSB, byte grouping U8/U16/U32) with live A/B switching during DSD playback
- Fix DSD/DoP wire silence to prevent audio pops and DC offset crackle
- Add DSD native failure diagnostics, offline dump capture, and compact rate labels

# Changes

## DSD-NATIVE Transport (SAS Offload)

- Add `dsd_sas_shim.rs` (629 lines) — vendor offload shim for internal DAC
- Add `dsd_sas_render_loop` with prefill gate, starvation telemetry, and wire capture for offline diffing
- Replace `is_alsa()` with `transport_name()` via `dsd_sas_shim::native_transport_name()`
- Set DSD wire silence flag around render loops to prevent DC offset/crackle
- Add DSD-NATIVE support via SAS offload shim with ALSA direct fallback

## UAC2 Preferences

- Add DSD wire variant and grouping preferences (bit order, byte grouping) with live A/B switching
- Add DSD rate labels to `Uac2AudioFormat`, compact rate labels in player status/indicator
- Add DSD native wire format settings to UAC2 preferences screen

## DSD Engine Fixes

- Fix DSD/DoP wire silence padding to prevent audio pops (`engine.rs`)
- Swap mute/volume feature unit IDs, clear inherited DSD flags for PCM requests
- Add bit reversal support to `DopPacker` and DOP packer logic
- Handle short reads in DSF/DFF decoders
- Use `MAX_VOLUME` constant for volume clamping

## DSD Diagnostics

- Track DSD native fallback failures with `last_failure()` accessor and clear function
- Add offline dump capture for DSD decoder threads
- Expose SAS wire variant and grouping controls

## Playback Improvements

- Add `allowRestart` parameter to `previous()` and new `previousBySwipe()` method
- Add `fileInfoRowVisible` param to `SongStage` (hidden via `Visibility` with maintained layout slot)
- Add debug print when audio session is missing

## Other

- Add native DSD on DAP internal DAC plan (382-line doc)
- Enhance audio APIs and adjust Android logging levels
- Include `albumArtist`, `genre`, and `year` in song search queries

## Files Changed

- `rust/src/audio/dsd_sas_shim.rs`
- `rust/src/audio/dsd_native_backend.rs`, `engine.rs`, `device.rs`, `mod.rs`
- `rust/src/audio/dsd_engine/dsd/dop.rs`, `output/mod.rs`, `dsd_thread.rs`
- `rust/src/audio/dsd_engine/format/dff_decoder.rs`, `dsf_decoder.rs`
- `rust/src/uac2/android_direct.rs`
- `rust/src/api/audio_api.rs`, `lib.rs`, `frb_generated.rs`
- `lib/services/uac2_preferences_service.rs`, `uac2_service.dart`, `rust_audio_service.dart`, `player_service.dart`, `android_audio_processing_service.dart`
- `lib/features/settings/screens/uac2_preferences_screen.dart`, `uac2_settings_screen.dart`
- `lib/widgets/uac2/uac2_status_indicator.dart`, `uac2_player_status.dart`
- `lib/features/player/widgets/song_stage.dart`, `bit_perfect_indicator.dart`
- `lib/providers/player_provider.dart`, `app_preferences_provider.dart`
- `lib/data/repositories/song_repository.dart`, `lib/app/app.dart`
- `docs/audio/dsd-native-dap-plan.md`