### PR TITLE
Improve EQ knob UX, persist USB prompt declines, and monitor USB routes at boot

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -35,6 +35,7 @@ import 'package:flick/features/onboarding/tutorial_targets.dart';
 import 'package:flick/features/onboarding/widgets/tutorial_overlay.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
+import 'package:flick/widgets/common/floating_mini_player.dart';
 import 'package:flick/widgets/common/floating_scan_progress.dart';
 import 'package:flick/widgets/uac2/usb_bit_perfect_prompt.dart';
 import 'package:flick/models/song.dart';
@@ -863,6 +864,9 @@ class _MainShellState extends ConsumerState<MainShell>
                     ),
                   ),
                 ),
+
+                // Floating island mini-player (draggable pill)
+                const FloatingMiniPlayer(),
 
                 // Floating scan/preload progress pill (overlay minimized)
                 const Positioned(

--- a/lib/features/settings/screens/equalizer_screen.dart
+++ b/lib/features/settings/screens/equalizer_screen.dart
@@ -7,7 +7,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flick/widgets/common/flick_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flick/widgets/common/floating_mini_player.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'dart:math' as math;
 import 'package:path_provider/path_provider.dart';
@@ -139,7 +138,6 @@ class _EqualizerScreenState extends ConsumerState<EqualizerScreen> {
             ),
           ),
         ),
-        const FloatingMiniPlayer(),
       ],
     );
   }

--- a/lib/features/settings/screens/equalizer_screen.dart
+++ b/lib/features/settings/screens/equalizer_screen.dart
@@ -309,6 +309,7 @@ class _LabeledKnob extends StatelessWidget {
   final double min;
   final double max;
   final ValueChanged<double>? onChanged;
+  final VoidCallback? onReset;
 
   const _LabeledKnob({
     required this.icon,
@@ -318,6 +319,7 @@ class _LabeledKnob extends StatelessWidget {
     this.min = 0.0,
     this.max = 1.0,
     required this.onChanged,
+    this.onReset,
   });
 
   static const double _knobSize = 80;
@@ -352,15 +354,22 @@ class _LabeledKnob extends StatelessWidget {
             ],
           ),
           const SizedBox(height: AppConstants.spacingSm),
-          RotaryKnob(
-            value: value,
-            min: min,
-            max: max,
-            size: _knobSize,
-            onChanged: onChanged,
-            label: label,
-            accentColor:
-                enabled ? context.adaptiveTextPrimary : context.adaptiveTextTertiary,
+          Tooltip(
+            message: enabled
+                ? 'Double-tap to reset'
+                : 'Enable EQ to edit',
+            child: RotaryKnob(
+              value: value,
+              min: min,
+              max: max,
+              size: _knobSize,
+              onChanged: onChanged,
+              onDoubleTap: onReset,
+              label: label,
+              accentColor: enabled
+                  ? context.adaptiveTextPrimary
+                  : context.adaptiveTextTertiary,
+            ),
           ),
           const SizedBox(height: AppConstants.spacingXs),
           _ValueBadge(value: valueLabel),
@@ -1598,6 +1607,8 @@ class _BmtKnobsRow extends ConsumerWidget {
                       ? (v) =>
                           ref.read(equalizerProvider.notifier).setBassDb(v)
                       : null,
+                  onReset: () =>
+                      ref.read(equalizerProvider.notifier).setBassDb(0.0),
                 ),
                 _LabeledKnob(
                   icon: LucideIcons.minus,
@@ -1611,6 +1622,8 @@ class _BmtKnobsRow extends ConsumerWidget {
                       ? (v) =>
                           ref.read(equalizerProvider.notifier).setMidDb(v)
                       : null,
+                  onReset: () =>
+                      ref.read(equalizerProvider.notifier).setMidDb(0.0),
                 ),
                 _LabeledKnob(
                   icon: LucideIcons.arrowUp,
@@ -1624,6 +1637,8 @@ class _BmtKnobsRow extends ConsumerWidget {
                       ? (v) =>
                           ref.read(equalizerProvider.notifier).setTrebleDb(v)
                       : null,
+                  onReset: () =>
+                      ref.read(equalizerProvider.notifier).setTrebleDb(0.0),
                 ),
               ],
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:flick/data/database.dart';
 import 'package:flick/services/external_playback_service.dart';
 import 'package:flick/services/permission_service.dart';
 import 'package:flick/services/player_service.dart';
+import 'package:flick/services/uac2_service.dart';
 import 'package:flick/core/utils/app_log.dart';
 import 'package:flick/core/utils/dev_log.dart';
 import 'package:flick/src/rust/api/logging.dart';
@@ -69,6 +70,11 @@ Future<void> _bootstrapAppAfterFirstFrame() async {
     _requestNotificationPermission().catchError(
       (Object e) => devLog('Notification permission request failed: $e'),
     ),
+  );
+  unawaited(
+    Uac2Service.instance
+        .initializeAndroidRouteMonitoring()
+        .catchError((Object e) => devLog('USB route probe failed: $e')),
   );
   unawaited(
     PlayerService().prepareForAppLaunch().catchError(

--- a/lib/services/uac2_preferences_service.dart
+++ b/lib/services/uac2_preferences_service.dart
@@ -52,6 +52,7 @@ class Uac2PreferencesService {
   static const _keyDsdSubslotOverride = 'dsd_subslot_override';
   static const _keyDsdWireVariant = 'dsd_wire_variant';
   static const _keyDsdWireGrouping = 'dsd_wire_grouping';
+  static const _keyPromptedUsbDevices = 'uac2_prompted_usb_devices';
 
   static bool get isDeveloperModeEnabledSync => developerModeNotifier.value;
   static bool get isKillIsochronousUsbOnQuitSync => killIsochronousUsbOnQuitNotifier.value;
@@ -683,6 +684,28 @@ class Uac2PreferencesService {
     }
   }
 
+  /// devices already showed the bit-perfect prompt for. One ask, ever.
+  Future<Set<String>> getPromptedUsbDevices() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      return prefs.getStringList(_keyPromptedUsbDevices)?.toSet() ?? <String>{};
+    } catch (e) {
+      devLog('Failed to load prompted USB devices: $e');
+      return <String>{};
+    }
+  }
+
+  Future<void> addPromptedUsbDevice(String promptKey) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final keys = prefs.getStringList(_keyPromptedUsbDevices) ?? <String>[];
+      if (keys.contains(promptKey)) return;
+      await prefs.setStringList(_keyPromptedUsbDevices, [...keys, promptKey]);
+    } catch (e) {
+      devLog('Failed to save prompted USB device: $e');
+    }
+  }
+
   Future<void> clearAllPreferences() async {
     try {
       final prefs = await SharedPreferences.getInstance();
@@ -710,6 +733,7 @@ await prefs.remove(_keyAudioEnginePreference);
     await prefs.remove(_keyDsdSubslotOverride);
     await prefs.remove(_keyDsdWireVariant);
     await prefs.remove(_keyDsdWireGrouping);
+    await prefs.remove(_keyPromptedUsbDevices);
       dsdOutputModeNotifier.value = DsdOutputMode.auto;
       dsdByteOrderOverrideNotifier.value = DsdByteOrderOverride.auto;
       dsdSubslotOverrideNotifier.value = null;

--- a/lib/services/uac2_service.dart
+++ b/lib/services/uac2_service.dart
@@ -322,6 +322,19 @@ class Uac2Service {
     await selectDevice(savedDevice);
   }
 
+  /// Boot-time probe: publish route status without activating devices or
+  /// starting the engine, so a DAC attached at launch surfaces (and can be
+  /// offered the bit-perfect prompt) before first play. Safe to call any time.
+  Future<void> initializeAndroidRouteMonitoring() async {
+    if (!Platform.isAndroid) return;
+    _configureAndroidChannel();
+    // Hydrate before publishing status or the prompt gate misfires for
+    // users who already have bit-perfect on.
+    bitPerfectEnabledNotifier.value =
+        await _preferencesService.getBitPerfectEnabled();
+    _scheduleAndroidRouteRefresh();
+  }
+
   void _configureAndroidChannel() {
     if (_androidChannelConfigured) return;
     _androidChannelConfigured = true;

--- a/lib/widgets/common/rotary_knob.dart
+++ b/lib/widgets/common/rotary_knob.dart
@@ -21,6 +21,7 @@ class RotaryKnob extends StatefulWidget {
   final double max;
   final double size;
   final ValueChanged<double>? onChanged;
+  final VoidCallback? onDoubleTap;
   final String label;
   final Color? accentColor;
   final bool showLabel;
@@ -32,6 +33,7 @@ class RotaryKnob extends StatefulWidget {
     required this.max,
     this.size = 110,
     required this.onChanged,
+    this.onDoubleTap,
     required this.label,
     this.accentColor,
     this.showLabel = false,
@@ -47,6 +49,8 @@ class _RotaryKnobState extends State<RotaryKnob>
   double _lastHapticValue = 0.0;
   double _targetValue = 0.0;
   bool _isDragging = false;
+  bool _dragMovedValue = false;
+  DateTime? _lastTapTime;
   late AnimationController _animController;
 
   // Pixels of arc travel for a full min->max sweep.
@@ -121,6 +125,7 @@ class _RotaryKnobState extends State<RotaryKnob>
     if (widget.onChanged == null) return;
     _animController.stop();
     _isDragging = true;
+    _dragMovedValue = false;
     _lastLocal = _localOf(globalPosition);
     _lastHapticValue = _currentValue;
   }
@@ -149,13 +154,19 @@ class _RotaryKnobState extends State<RotaryKnob>
 
     final newValue = (_currentValue + travel * range / _fullSweepPixels)
         .clamp(widget.min, widget.max);
-    final snapped = (newValue * 10).round() / 10.0;
+    // Snap relative to the knob's range (0.33% steps) so short-range knobs
+    // (0..1 mix/size, 0.5..2 tempo) stay smooth instead of jumping 10%.
+    final snapStep = range / 300;
+    final snapped =
+        ((newValue - widget.min) / snapStep).round() * snapStep + widget.min;
 
     final diff = (snapped - _lastHapticValue).abs();
-    if (diff >= 0.5) {
+    if (diff >= range * 0.02) {
       AppHaptics.selection();
       _lastHapticValue = snapped;
     }
+
+    if (snapped != _currentValue) _dragMovedValue = true;
 
     setState(() => _currentValue = snapped);
     widget.onChanged!(_currentValue);
@@ -163,6 +174,17 @@ class _RotaryKnobState extends State<RotaryKnob>
 
   void _handleDragEnd() {
     _isDragging = false;
+    if (_dragMovedValue) return;
+    // The eager-accepting drag recognizer wins the arena before any outer
+    // GestureDetector, so double-tap is detected here from bare taps.
+    final now = DateTime.now();
+    final previous = _lastTapTime;
+    _lastTapTime = now;
+    if (previous != null &&
+        now.difference(previous) <= const Duration(milliseconds: 300)) {
+      _lastTapTime = null;
+      widget.onDoubleTap?.call();
+    }
   }
 
   @override
@@ -178,6 +200,7 @@ class _RotaryKnobState extends State<RotaryKnob>
             GestureRecognizerFactoryWithHandlers<_KnobDragGestureRecognizer>(
           () => _KnobDragGestureRecognizer(),
           (instance) {
+            instance.enabled = widget.onChanged != null;
             instance.onDragStart = _handleDragStart;
             instance.onDragUpdate = _handleDragUpdate;
             instance.onDragEnd = _handleDragEnd;
@@ -305,6 +328,10 @@ class KnobArcPainter extends CustomPainter {
 class _KnobDragGestureRecognizer extends OneSequenceGestureRecognizer {
   _KnobDragGestureRecognizer();
 
+  // When false (knob disabled), the pointer is not claimed so parent
+  // scrollables (PageView, ListView) handle the drag normally.
+  bool enabled = true;
+
   void Function(Offset globalPosition)? onDragStart;
   void Function(Offset globalPosition)? onDragUpdate;
   void Function()? onDragEnd;
@@ -312,6 +339,7 @@ class _KnobDragGestureRecognizer extends OneSequenceGestureRecognizer {
   @override
   void addAllowedPointer(PointerDownEvent event) {
     startTrackingPointer(event.pointer);
+    if (!enabled) return;
     // Eagerly accept — this wins the gesture arena over parent
     // scrollables (e.g. PageView, ListView) immediately.
     resolve(GestureDisposition.accepted);

--- a/lib/widgets/uac2/usb_bit_perfect_prompt.dart
+++ b/lib/widgets/uac2/usb_bit_perfect_prompt.dart
@@ -32,6 +32,7 @@ String usbDevicePromptKey(Uac2DeviceInfo device) =>
 
 /// Auto-detects a connected USB DAC and offers a one-tap switch to
 /// Bit-perfect (USB DAC) mode. Renders nothing; mount once in the shell.
+/// Asks once per device, ever — declines are persisted.
 class UsbBitPerfectPrompt extends ConsumerStatefulWidget {
   const UsbBitPerfectPrompt({super.key});
 
@@ -41,8 +42,8 @@ class UsbBitPerfectPrompt extends ConsumerStatefulWidget {
 }
 
 class _UsbBitPerfectPromptState extends ConsumerState<UsbBitPerfectPrompt> {
-  // ponytail: session-only decline memory; persistent "don't ask again" pref
-  // if nagging complaints arrive
+  // Race guard for bursty status events only; the persisted list in
+  // Uac2PreferencesService is the real once-per-device memory.
   final Set<String> _promptedDevices = {};
 
   @override
@@ -66,13 +67,22 @@ class _UsbBitPerfectPromptState extends ConsumerState<UsbBitPerfectPrompt> {
       return;
     }
 
-    if (!_promptedDevices.add(usbDevicePromptKey(status.device))) return;
+    final promptKey = usbDevicePromptKey(status.device);
+    if (!_promptedDevices.add(promptKey)) return;
+
+    final preferences = ref.read(uac2PreferencesServiceProvider);
+    try {
+      if ((await preferences.getPromptedUsbDevices()).contains(promptKey)) {
+        return;
+      }
+      await preferences.addPromptedUsbDevice(promptKey);
+    } catch (_) {
+      return;
+    }
 
     final AudioEnginePreference engine;
     try {
-      engine = await ref
-          .read(uac2PreferencesServiceProvider)
-          .getAudioEnginePreference();
+      engine = await preferences.getAudioEnginePreference();
     } catch (_) {
       return;
     }

--- a/test/widgets/uac2/usb_bit_perfect_prompt_test.dart
+++ b/test/widgets/uac2/usb_bit_perfect_prompt_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flick/services/uac2_preferences_service.dart';
 import 'package:flick/services/uac2_service.dart';
 import 'package:flick/widgets/uac2/usb_bit_perfect_prompt.dart';
 
@@ -108,5 +110,22 @@ void main() {
     expect(a, b);
     expect(<String>{}..add(a)..add(b), {a});
     expect(noSerial, '1:2:/dev/bus/usb/001/002');
+  });
+
+  test('prompted devices persist across sessions', () async {
+    SharedPreferences.setMockInitialValues({});
+    final service = Uac2PreferencesService();
+
+    expect(await service.getPromptedUsbDevices(), isEmpty);
+
+    await service.addPromptedUsbDevice('1:2:S1');
+    await service.addPromptedUsbDevice('1:2:S1');
+    await service.addPromptedUsbDevice('3:4:S2');
+
+    final persisted = await service.getPromptedUsbDevices();
+    expect(persisted, {'1:2:S1', '3:4:S2'});
+
+    await service.clearAllPreferences();
+    expect(await service.getPromptedUsbDevices(), isEmpty);
   });
 }


### PR DESCRIPTION
# Summary

- Add double-tap reset and tooltip to EQ knobs with refined rotary knob dragging
- Persist USB bit-perfect prompt declines per device (not just per session)
- Add Android USB route monitoring initialization at boot
- Move floating mini player to main shell

# Changes

## Equalizer Knob UX

- Add `onDoubleTap` callback and refine rotary knob dragging (drag threshold, sweep behavior)
- Add double-tap reset and tooltip to EQ knobs

## USB Bit-Perfect Prompt

- Persist declined USB bit-perfect prompts per device in `Uac2PreferencesService`
- Keep in-memory `_promptedDevices` set as race guard against bursty status events
- Add UAC2 preferences persistence test

## USB Route Monitoring

- Add Android route monitoring initialization for boot in `uac2_service.dart` and `main.dart`

## App Shell

- Move floating mini player to main shell for persistent access

## Files Changed

- `lib/widgets/common/rotary_knob.dart`
- `lib/features/settings/screens/equalizer_screen.dart`
- `lib/widgets/uac2/usb_bit_perfect_prompt.dart`
- `lib/services/uac2_service.dart`
- `lib/main.dart`, `lib/app/app.dart`
- `test/widgets/uac2/usb_bit_perfect_prompt_test.dart`