### PR TITLE
Add Apple Music Motion Art playback with sibling cover fallbacks, and prepare 0.22.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,62 @@
 # Changelog
 
+## 0.22.0-beta.1 (2026-09-10)
+
+### DSD Native Playback
+- **DSD-NATIVE output** via SAS offload shim (HiBy devices) with ALSA direct fallback.
+- DoP packer bit-reversal; short reads handled; wire silence padding fixes audio pops.
+- DSD wire format and grouping settings in UAC2 preferences; restored output mode and transport overrides.
+- DSD reconciliation finds unindexed DSD files; decoder crash dumps captured offline.
+
+### ReplayGain & Crossfeed
+- **ReplayGain** Track/Album modes with pre-amp and clipping prevention.
+- Scanner analyzes loudness (EBU R128 / BS.1770), writes `REPLAYGAIN_*` tags, and updates the library.
+- **BS2B crossfeed** with Default/strong/gentle presets; persists across engine recreation; bypassed on bit-perfect.
+
+### Karaoke Lyrics
+- Word-level **karaoke sync** with gradient sweep and a toggle in lyrics settings.
+- Full-screen **Lyrics Sync Studio**: tap-along word stamping, enhanced LRC export, video-style word timeline, syllable splitting.
+- Lyrics from **MP4/M4A and OGG/Opus** containers; text alignment options and readability scrim.
+
+### Global Search
+- Unified search across songs, albums, artists, and playlists.
+- Filter chips with persisted selection; refined search screen.
+
+### Library Scanning & Permissions
+- Optional **Full Library Access** — Rust scanner walks every volume directly; falls back to MediaStore/SAF.
+- **DSD/DSF/WavPack always scanned**, even on devices whose media indexer skips them (Xiaomi/MIUI, Vivo, Honor).
+- **WavPack/DSD tags & album art everywhere** via Rust parser fallback; fixed DFF/WavPack embedded covers.
+- **Fixed library wipe when switching scan engines** — each engine only deletes rows it can see.
+- Floating minimizable scan progress pill; preload runs as one cancellable pass with a Stop button.
+
+### Engine Recovery & Accuracy
+- Rust engine **crash recovery** — revives on dead channels with panic reporting.
+- Lying container headers detected and corrected; implausible sample rates filtered.
+
+### Navigation & UI Refresh
+- Nested navigators per tab; full player and queue routed via root navigator.
+- New **FlickDialog** system and **FlickArtworkPlaceholder** across the app.
+- Shared detail headers with glass blur back buttons; landscape mode support.
+- System **reduced-motion** preference respected globally.
+
+### USB & Bluetooth
+- Bit-perfect **auto-prompt on DAC attach**, with per-device decline memory.
+- UAC1: refuses direct USB when SET_CUR fails; better sampling-frequency negotiation.
+- USB route monitoring at boot; Hi-Res Direct for the Bluetooth Rust Oboe path.
+
+### Network Sources
+- Jellyfin **silent re-auth** via secure password store; auth failure detection.
+- Tidal sign-in fix with persisted session token.
+
+### Player & Library
+- Rebuilt full player with song stage carousel; swipe-down previous-track gesture.
+- Metadata editor moved to a bottom sheet with instant sync.
+- Playlist sorting; bulk favorites; duplicate cleaner with per-group multi-keep.
+- Folder tree view toggle; EQ knobs double-tap to reset.
+
 ## Currently on Pre-release
 
 Changes landing on top of the current pre-release are tracked here and folded into the release notes as they ship.
-
-### Library Scanning & Permissions
-- Optional **Full Library Access** (`MANAGE_EXTERNAL_STORAGE`) mode: when granted, library scans walk the filesystem directly via the Rust scanner on every volume (internal storage, SD cards, USB drives) — same approach as Poweramp/USB Audio Player PRO — so no file can hide behind an incomplete system media index. Degrades gracefully to MediaStore/SAF when not granted. Toggle + status in Settings → Library → Scan Settings.
-- **DSD/DSF/WavPack now always scanned** even in scoped-storage mode: on devices whose media indexer skips DSD entirely (Xiaomi/MIUI, Vivo, Honor and similar), a stat-only reconciliation walk finds the missing `.dsf`/`.dff`/`.wv` files during every scan, plus a best-effort MediaStore re-index nudge; live-change watching now covers the Files collection too.
-- **Fixed library wipe when switching scan engines** (e.g. after granting Full Library Access): each scan engine now only deletes rows in the URI space it can actually see — SAF `content://` rows are superseded by their raw-path equivalents (never dropped before the replacement exists), and Rust/MediaStore scans no longer feed SAF-keyed rows into filesystem deletion checks. Also protects periodic background deletion refreshes.
-- **WavPack/DSD tags & album art everywhere**: Android's metadata reader cannot decode WavPack at all (and often not DSD), so `.wv`/`.dsf`/`.dff` tracks scanned via MediaStore/SAF used to land with no title, duration, or cover. Metadata enrichment now falls back to the app's own Rust parsers (lofty/dsf-meta/dff-meta) for those formats — including SAF locations, staged through the shared playback cache — and embedded covers are extracted the same way. Also fixes DSD bitrate being stored ~1000× too low in deep scans.
-- **Fixed DFF/WavPack embedded covers**: WavPack stores its APE cover art as binary tag items (invisible to lofty's picture API) and dff-meta aborts on imperfect DFF ID3 chunks — covers for both now extract through a direct APE-item scan and a tolerant DSDIFF chunk walker, with DFF text tags recovered the same way when dff-meta gives up.
-- **Fixed post-scan audio preload grinding invisibly**: the background decode pass (waveform/loudness) now runs as a single cancellable pass — cancelling or restarting a scan stops it, overlapping passes can no longer stack decoders or freeze artwork extraction, live progress with a Stop button appears on the scan-complete sheet, and undecodable formats (DSD/WavPack) are negative-cached instead of being re-probed on every pass.
-- **Minimizable scan progress**: the scanning overlay (library scan, preload, ReplayGain) gains a Minimize button; a floating pill above the bottom bar keeps showing live progress (counts, current file, elapsed, Stop) while you keep using the app, and also surfaces post-scan preload passes running in the background.
-
-### Headphone Crossfeed
-- BS2B (Bauer stereophonic-to-binaural) 3-stage crossfeed with selectable presets — Default, Crossfeed (strong), and Crossfeed easy (gentle), plus Off. Blends a low-passed opposite-channel signal into each channel to reduce ear fatigue on headphones; runs in the native Rust DSP chain, bypassed on bit-perfect passthrough.
-- Crossfeed level persists across engine recreation (e.g. sample-rate changes between tracks).
-
-### ReplayGain
-- ReplayGain playback (Track & Album modes) with pre-amp and clipping prevention — applied per source by the native engine and folded into the just_audio volume path.
-- ReplayGain scanner in Library settings: analyzes loudness (EBU R128 / BS.1770), writes `REPLAYGAIN_*` tags back into files, and updates the library database.
-- Library scans now read existing `REPLAYGAIN_*` tags (FLAC/Vorbis, MP3/ID3, MP4, WAV/AIFF, plus DSF/DFF ID3 tags).
-
-### Folders
-- Hierarchy (tree) view now available inside folders via the grid/list toggle — matches the root Folders screen; view mode persists across screens.
-
-### Lyrics
-- **Lyrics Sync Studio is now a full screen** instead of a cramped bottom sheet: a pinned playback bar (play/pause, ±2s, live position with a song progress line), a slim Lines/Stamped/Words status strip, and a Lines/Tools split — side-by-side panes on tablet/desktop, two tabs on phone. The raw lyrics text editor moved into a dedicated "Edit Text" action, Simple mode pins "Stamp & Next" under the line list, and Advanced mode edits the selected line's timestamp in a focused workspace. Leaving with unsaved stamps now asks for confirmation instead of silently discarding.
-- **Word Sync (karaoke) editing** in the Lyrics Sync Studio: play the song and tap along to stamp each word; fully stamped lines export as enhanced LRC (`<mm:ss.xx>` word tags) that drives the karaoke sweep. Word chips support per-word nudge/re-time/clear, a live karaoke preview shows the real sweep while editing, and existing word timings now survive editing — re-stamping a line shifts its words by the same delta instead of discarding them.
-- **Video-style word timeline** in Advanced mode: each word renders as a clip whose length you control — drag a boundary to stretch or shrink the adjacent words (all edits snap to the 10ms LRC grid), drag the line-end boundary (or use Length ± buttons) to retime the next line, set exact start times numerically, and Auto-fill seeds evenly spaced words as a drag starting point. Words can also be split into separately timed syllables (tap-a-letter splitter) for slow-then-fast pacing inside a single word — saved as adjacent enhanced-LRC word tags.
-- Embedded lyrics now read from MP4/M4A `©lyr` atoms (UTF-8 and UTF-16) and OGG/Opus Vorbis comments, joining existing ID3 (USLT/SYLT) and FLAC support.
 
 ## 0.21.0-beta.1 (2026-07-10)
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -25,10 +25,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         compose = true
     }
@@ -69,12 +65,6 @@ android {
         }
     }
 
-    sourceSets {
-        getByName("main") {
-            jniLibs.srcDirs("src/main/jniLibs")
-        }
-    }
-
     buildTypes {
         release {
             signingConfig = signingConfigs.getByName("release")
@@ -86,6 +76,12 @@ android {
 
 flutter {
     source = "../.."
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }
 
 // Copy libc++_shared.so from NDK before building
@@ -175,14 +171,13 @@ tasks.register("copyNdkLibs") {
 
                 if (llvmStrip != null) {
                     val sizeBeforeBytes = outputLib.length()
-                    val stripResult =
-                        project.exec {
-                            executable = llvmStrip
-                            args("--strip-debug", outputLib.absolutePath)
-                            isIgnoreExitValue = true
-                        }
+                    val exitCode =
+                        ProcessBuilder(llvmStrip, "--strip-debug", outputLib.absolutePath)
+                            .redirectErrorStream(true)
+                            .start()
+                            .waitFor()
 
-                    if (stripResult.exitValue == 0) {
+                    if (exitCode == 0) {
                         val sizeAfterBytes = outputLib.length()
                         logger.lifecycle(
                             "Stripped libc++_shared.so for $abi: ${sizeBeforeBytes / 1024} KB -> ${sizeAfterBytes / 1024} KB",

--- a/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
@@ -394,6 +394,23 @@ class MainActivity: FlutterActivity() {
                         result.error("INVALID_ARGUMENT", "URI is required", null)
                     }
                 }
+                "readSiblingArtwork" -> {
+                    val uri = call.argument<String>("uri")
+                    if (uri != null) {
+                        mainScope.launch {
+                            try {
+                                val artwork = withContext(Dispatchers.IO) {
+                                    readSiblingArtwork(uri)
+                                }
+                                result.success(artwork)
+                            } catch (e: Exception) {
+                                result.error("ARTWORK_ERROR", "Failed to read sibling artwork: ${e.message}", null)
+                            }
+                        }
+                    } else {
+                        result.error("INVALID_ARGUMENT", "URI is required", null)
+                    }
+                }
                 "readSiblingLyrics" -> {
                     val audioUri = call.argument<String>("audioUri")
                     if (audioUri != null) {
@@ -2543,6 +2560,110 @@ class MainActivity: FlutterActivity() {
             }
         } catch (e: Exception) {
             android.util.Log.w("FlickLyrics", "readSiblingLyrics failed for $audioUriString: ${e.message}")
+            null
+        }
+    }
+
+    private val siblingArtworkStems = listOf("cover", "folder", "album", "albumart", "front")
+    private val siblingArtworkExtensions = setOf("jpg", "jpeg", "png", "webp", "gif", "bmp")
+
+    private fun readSiblingArtwork(sourceUriString: String): ByteArray? {
+        return try {
+            val sourceUri = Uri.parse(sourceUriString)
+            when (sourceUri.scheme) {
+                "content" -> readSiblingArtworkFromContentUri(sourceUri)
+                "file" -> readSiblingArtworkFromFilePath(sourceUri.path)
+                null, "" -> readSiblingArtworkFromFilePath(sourceUriString)
+                else -> null
+            }
+        } catch (e: Exception) {
+            android.util.Log.w("FlickArtwork", "readSiblingArtwork failed for $sourceUriString: ${e.message}")
+            null
+        }
+    }
+
+    private fun readSiblingArtworkFromContentUri(audioUri: Uri): ByteArray? {
+        val authority = audioUri.authority ?: return null
+        val documentId = try {
+            DocumentsContract.getDocumentId(audioUri)
+        } catch (e: Exception) {
+            return null
+        }
+        val slashIndex = documentId.lastIndexOf('/')
+        if (slashIndex <= 0) return null
+        val parentDocumentId = documentId.substring(0, slashIndex)
+
+        val childrenUri = try {
+            DocumentsContract.buildChildDocumentsUri(authority, parentDocumentId)
+        } catch (e: Exception) {
+            return null
+        }
+
+        contentResolver.query(
+            childrenUri,
+            arrayOf(
+                DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+            ),
+            null,
+            null,
+            null,
+        )?.use { cursor ->
+            val idIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+            val nameIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+            if (idIndex == -1 || nameIndex == -1) return null
+
+            val matches = mutableListOf<Pair<String, String>>()
+            while (cursor.moveToNext()) {
+                val displayName = cursor.getString(nameIndex) ?: continue
+                if (!isSiblingArtworkName(displayName)) continue
+                val childDocumentId = cursor.getString(idIndex) ?: continue
+                matches.add(displayName to childDocumentId)
+            }
+            matches.sortBy { it.first.lowercase() }
+
+            for ((_, childDocumentId) in matches) {
+                val childUri = DocumentsContract.buildDocumentUri(authority, childDocumentId)
+                val bytes = readBytesFromUri(childUri)
+                if (bytes != null && bytes.isNotEmpty()) return bytes
+            }
+        }
+
+        return null
+    }
+
+    private fun readSiblingArtworkFromFilePath(audioPath: String?): ByteArray? {
+        if (audioPath.isNullOrBlank()) return null
+        val parent = java.io.File(audioPath).parentFile ?: return null
+        val covers = parent.listFiles()
+            ?.filter { it.isFile && isSiblingArtworkName(it.name) }
+            ?.sortedBy { it.name.lowercase() }
+            ?: return null
+
+        for (cover in covers) {
+            try {
+                return cover.readBytes()
+            } catch (_: Exception) {
+                // try the next candidate
+            }
+        }
+        return null
+    }
+
+    private fun isSiblingArtworkName(name: String): Boolean {
+        val dot = name.lastIndexOf('.')
+        if (dot <= 0) return false
+        val stem = name.substring(0, dot).lowercase()
+        if (!siblingArtworkExtensions.contains(name.substring(dot + 1).lowercase())) {
+            return false
+        }
+        return siblingArtworkStems.any { stem == it || stem.startsWith("$it.") }
+    }
+
+    private fun readBytesFromUri(uri: Uri): ByteArray? {
+        return try {
+            contentResolver.openInputStream(uri)?.use { it.readBytes() }
+        } catch (_: Exception) {
             null
         }
     }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,6 +5,18 @@ allprojects {
     }
 }
 
+// file_picker 11.x skips the Kotlin Gradle Plugin on AGP 9+ expecting built-in Kotlin,
+// but this project runs KGP mode (android.builtInKotlin=false). Apply it manually and
+// align jvmTarget with the plugin's Java 17 compileOptions.
+project(":file_picker") {
+    pluginManager.apply("org.jetbrains.kotlin.android")
+    plugins.withId("org.jetbrains.kotlin.android") {
+        extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension> {
+            compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
+    }
+}
+
 val newBuildDir: Directory =
     rootProject.layout.buildDirectory
         .dir("../../build")

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,12 +1,8 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.nonTransitiveRClass=false
-android.defaults.buildfeatures.buildconfig=true
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator
 android.newDsl=false
-# This builtInKotlin flag was added automatically by Flutter migrator
-android.builtInKotlin=false
-# This newDsl flag was added automatically by Flutter migrator
-android.newDsl=false
+

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -27,9 +27,9 @@ dependencyResolutionManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.11.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.2.20" apply false
+    id("com.android.application") version "9.1.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.0" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.4.0" apply false
     id("com.google.gms.google-services") version "4.4.4" apply false
 }
 

--- a/docs/RELEASE_0.22.0-beta.1.md
+++ b/docs/RELEASE_0.22.0-beta.1.md
@@ -1,0 +1,70 @@
+# Flick 0.22.0-beta.1
+
+## DSD Native Playback
+
+- **DSD-NATIVE output** via SAS offload shim (HiBy devices) with ALSA direct fallback
+- DoP packer bit-reversal; short reads handled; wire silence padding fixes audio pops
+- DSD wire format and grouping settings in UAC2 preferences; restored output mode and transport overrides
+- DSD reconciliation finds unindexed DSD files; decoder crash dumps captured offline
+
+## ReplayGain & Crossfeed
+
+- **ReplayGain** Track/Album modes with pre-amp and clipping prevention
+- Scanner analyzes loudness (EBU R128 / BS.1770), writes `REPLAYGAIN_*` tags, and updates the library
+- **BS2B crossfeed** with Default/strong/gentle presets; persists across engine recreation; bypassed on bit-perfect
+
+## Karaoke Lyrics
+
+- Word-level **karaoke sync** with gradient sweep and a toggle in lyrics settings
+- Full-screen **Lyrics Sync Studio**: tap-along word stamping, enhanced LRC export, video-style word timeline, syllable splitting
+- Lyrics from **MP4/M4A and OGG/Opus** containers; text alignment options and readability scrim
+
+## Global Search
+
+- Unified search across songs, albums, artists, and playlists
+- Filter chips with persisted selection; refined search screen
+
+## Library Scanning & Permissions
+
+- Optional **Full Library Access** — Rust scanner walks every volume directly; falls back to MediaStore/SAF
+- **DSD/DSF/WavPack always scanned**, even on devices whose media indexer skips them (Xiaomi/MIUI, Vivo, Honor)
+- **WavPack/DSD tags & album art everywhere** via Rust parser fallback; fixed DFF/WavPack embedded covers
+- **Fixed library wipe when switching scan engines** — each engine only deletes rows it can see
+- Floating minimizable scan progress pill; preload runs as one cancellable pass with a Stop button
+
+## Engine Recovery & Accuracy
+
+- Rust engine **crash recovery** — revives on dead channels with panic reporting
+- Lying container headers detected and corrected; implausible sample rates filtered
+
+## Navigation & UI Refresh
+
+- Nested navigators per tab; full player and queue routed via root navigator
+- New **FlickDialog** system and **FlickArtworkPlaceholder** across the app
+- Shared detail headers with glass blur back buttons; landscape mode support
+- System **reduced-motion** preference respected globally
+
+## USB & Bluetooth
+
+- Bit-perfect **auto-prompt on DAC attach**, with per-device decline memory
+- UAC1: refuses direct USB when SET_CUR fails; better sampling-frequency negotiation
+- USB route monitoring at boot; Hi-Res Direct for the Bluetooth Rust Oboe path
+
+## Network Sources
+
+- Jellyfin **silent re-auth** via secure password store; auth failure detection
+- Tidal sign-in fix with persisted session token
+
+## Player & Library
+
+- Rebuilt full player with song stage carousel; swipe-down previous-track gesture
+- Metadata editor moved to a bottom sheet with instant sync
+- Playlist sorting; bulk favorites; duplicate cleaner with per-group multi-keep
+- Folder tree view toggle; EQ knobs double-tap to reset
+
+## Getting Started
+
+1. ReplayGain: Settings → Library → Scan Settings → ReplayGain scan
+2. Crossfeed: Settings → Audio → Headphone Crossfeed
+3. Karaoke: Lyrics settings → Word Sync toggle, then edit in the Sync Studio
+4. Full Library Access: Settings → Library → Scan Settings

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -1,8 +1,8 @@
 /// Current marketing version of the app (matches the `version` field in
 /// `pubspec.yaml`). Bump in lockstep with each release.
-const String kAppVersion = '0.21.0-beta.1';
-const String kAppBuild = '25';
-/// Human-friendly version label, e.g. `0.21.0-beta.1 (build 25)`.
+const String kAppVersion = '0.22.0-beta.1';
+const String kAppBuild = '27';
+/// Human-friendly version label, e.g. `0.22.0-beta.1 (build 27)`.
 const String kAppVersionLabel = '$kAppVersion (build $kAppBuild)';
 
 /// App-wide constants for Flick Player.

--- a/lib/features/albums/screens/album_detail_screen.dart
+++ b/lib/features/albums/screens/album_detail_screen.dart
@@ -604,6 +604,11 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen>
         dominantColor: _albumColor,
         placeholder: fallback,
         errorWidget: fallback,
+        albumName: widget.albumName,
+        artistName: widget.albumArtist,
+        representativeSongTitle: widget.songs.isNotEmpty
+            ? widget.songs.first.title
+            : null,
       ),
     );
   }

--- a/lib/features/albums/screens/albums_screen.dart
+++ b/lib/features/albums/screens/albums_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
@@ -13,6 +15,7 @@ import 'package:flick/features/albums/screens/album_detail_screen.dart';
 import 'package:flick/features/player/widgets/ambient_background.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/services/player_service.dart';
+import 'package:flick/services/motion_art/animated_artwork_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/surface_icon_button.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
@@ -78,6 +81,28 @@ class _AlbumsScreenState extends ConsumerState<AlbumsScreen> {
         _applySorting();
         _isLoading = false;
       });
+      unawaited(_prefetchMotionArt(albums));
+    }
+  }
+
+  // Warm a bounded set of album lookups so opening an album hero or playing a
+  // track does not wait on a cold network call. Only metadata is fetched here;
+  // the video itself streams lazily when a widget actually becomes visible.
+  // Sequential with a gap because boidu's upstream rate-limits bursts.
+  Future<void> _prefetchMotionArt(List<AlbumGroup> albums) async {
+    final prefs = ref.read(appPreferencesProvider);
+    if (!prefs.animatedAlbumArt || !prefs.animationsEnabled) return;
+    final service = AnimatedArtworkService.instance;
+    for (final album in albums.take(8)) {
+      if (!mounted) return;
+      await service.getAnimatedArtworkForAlbum(
+        albumName: album.albumName,
+        artist: album.albumArtist,
+        representativeSongTitle: album.songs.isNotEmpty
+            ? album.songs.first.title
+            : null,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 400));
     }
   }
 

--- a/lib/features/onboarding/screens/onboarding_screen.dart
+++ b/lib/features/onboarding/screens/onboarding_screen.dart
@@ -76,10 +76,16 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen>
 
   void _goToNext() {
     if (_currentPage < _totalPages - 1) {
-      _pageController.nextPage(
-        duration: AppConstants.animationNormal,
-        curve: Curves.easeOutCubic,
-      );
+      final next = _currentPage + 1;
+      if (AppConstants.animationNormal == Duration.zero) {
+        _pageController.jumpToPage(next);
+      } else {
+        _pageController.animateToPage(
+          next,
+          duration: AppConstants.animationNormal,
+          curve: Curves.easeOutCubic,
+        );
+      }
     } else {
       _complete();
     }

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -27,6 +27,7 @@ import 'package:flick/services/external_playback_service.dart';
 import 'package:flick/services/favorites_service.dart';
 import 'package:flick/services/lyrics_service.dart';
 import 'package:flick/services/player_screen_mode_preference_service.dart';
+import 'package:flick/widgets/common/animated_album_art.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
@@ -328,6 +329,7 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
     String visStyle,
     String visFreq,
     String visMove,
+    bool animatedArtwork,
   ) {
     final bgBlend = albumColorMode.backgroundBlend;
     final hasAlbumTint = albumColor != null && bgBlend > 0;
@@ -350,6 +352,7 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
             visStyle,
             visFreq,
             visMove,
+            animatedArtwork,
           ),
         ),
         Positioned.fill(
@@ -377,6 +380,7 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
     String visStyle,
     String visFreq,
     String visMove,
+    bool animatedArtwork,
   ) {
     final bgBlend = albumColorMode.backgroundBlend;
     final hasAlbumTint = albumColor != null && bgBlend > 0;
@@ -488,27 +492,37 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
             gradientBase.withValues(alpha: 0.3),
             Colors.transparent,
           ];
-    return Stack(
-      children: [
-        Positioned.fill(
-          child: CachedImageWidget(
+    final placeholder = Container(
+      color: AppColors.background,
+      child: const Center(
+        child: FlickArtworkPlaceholder(size: 96, opacity: 0.35),
+      ),
+    );
+    final hasArtwork = song.albumArt != null || song.filePath != null;
+    final artLayer = animatedArtwork && hasArtwork
+        ? AnimatedAlbumArt(
+            imagePath: song.albumArt,
+            audioSourcePath: song.filePath,
+            dominantColor: albumColor,
+            placeholder: placeholder,
+            errorWidget: placeholder,
+            albumName: song.album,
+            artistName:
+                (song.albumArtist != null && song.albumArtist!.trim().isNotEmpty)
+                ? song.albumArtist
+                : song.artist,
+            representativeSongTitle: song.title,
+          )
+        : CachedImageWidget(
             imagePath: song.albumArt,
             audioSourcePath: song.filePath,
             fit: BoxFit.cover,
-            placeholder: Container(
-              color: AppColors.background,
-              child: const Center(
-                child: FlickArtworkPlaceholder(size: 96, opacity: 0.35),
-              ),
-            ),
-            errorWidget: Container(
-              color: AppColors.background,
-              child: const Center(
-                child: FlickArtworkPlaceholder(size: 96, opacity: 0.35),
-              ),
-            ),
-          ),
-        ),
+            placeholder: placeholder,
+            errorWidget: placeholder,
+          );
+    return Stack(
+      children: [
+        Positioned.fill(child: artLayer),
         Positioned.fill(
           child: AnimatedContainer(
             duration: AppConstants.animationNormal,
@@ -1009,6 +1023,7 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
       visStyle,
       visFreq,
       visMove,
+      appPrefs.animatedAlbumArt && appPrefs.animationsEnabled,
     );
 
     if (showVisualizerOnly) {

--- a/lib/features/player/widgets/album_art_box.dart
+++ b/lib/features/player/widgets/album_art_box.dart
@@ -2,14 +2,18 @@ import 'dart:math' as math;
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/core/utils/app_haptics.dart';
 import 'package:flick/core/utils/responsive.dart';
+import 'package:flick/features/player/widgets/motion_art_widget.dart';
+import 'package:flick/providers/app_preferences_provider.dart';
+import 'package:flick/widgets/common/animated_album_art.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 
-class AlbumArtBox extends StatefulWidget {
+class AlbumArtBox extends ConsumerStatefulWidget {
   final Song song;
   final double? size;
   final PlayerService? playerService;
@@ -30,10 +34,10 @@ class AlbumArtBox extends StatefulWidget {
   });
 
   @override
-  State<AlbumArtBox> createState() => _AlbumArtBoxState();
+  ConsumerState<AlbumArtBox> createState() => _AlbumArtBoxState();
 }
 
-class _AlbumArtBoxState extends State<AlbumArtBox>
+class _AlbumArtBoxState extends ConsumerState<AlbumArtBox>
     with TickerProviderStateMixin {
   static const double _labelRatio = 0.44;
   static const Duration _spinDuration = Duration(seconds: 4);
@@ -318,10 +322,68 @@ class _AlbumArtBoxState extends State<AlbumArtBox>
     }
   }
 
+  Widget _buildArtContent({
+    required double iconSize,
+    required double t,
+    required bool motionEnabled,
+  }) {
+    final placeholder = Container(
+      color: Colors.white.withValues(alpha: 0.05),
+      child: Transform.translate(
+        offset: Offset(0, 6 * (1 - t)),
+        child: FlickArtworkPlaceholder(
+          size: iconSize * (1 - t * 0.5) * 1.42,
+          opacity: 0.92,
+        ),
+      ),
+    );
+    final staticArt = CachedImageWidget(
+      imagePath: widget.song.albumArt,
+      audioSourcePath: widget.song.filePath,
+      fit: BoxFit.cover,
+      placeholder: placeholder,
+      errorWidget: placeholder,
+    );
+    // No Apple Motion Art: keep the art alive with the same Ken Burns treatment
+    // the detail heroes use. Static while the disc is spinning so the pan does
+    // not fight the rotation.
+    final fallback = _isVinyl
+        ? staticArt
+        : AnimatedAlbumArt(
+            imagePath: widget.song.albumArt,
+            audioSourcePath: widget.song.filePath,
+            placeholder: placeholder,
+            errorWidget: placeholder,
+          );
+    final album = widget.song.album;
+    final albumArtist = widget.song.albumArtist;
+    final useAlbum = album != null && album.trim().isNotEmpty;
+    return MotionArtView(
+      title: useAlbum ? album : widget.song.title,
+      artist: (albumArtist != null && albumArtist.trim().isNotEmpty)
+          ? albumArtist
+          : widget.song.artist,
+      album: album,
+      albumMode: useAlbum,
+      representativeSongTitle: useAlbum ? widget.song.title : null,
+      duration: widget.song.duration,
+      enabled: motionEnabled && !_isVinyl,
+      fallback: fallback,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final double resolvedSize =
         widget.size ?? context.responsive(280.0, 320.0, 360.0);
+
+    final motionEnabled =
+        ref.watch(
+          appPreferencesProvider.select(
+            (p) => p.animatedAlbumArt && p.animationsEnabled,
+          ),
+        ) &&
+        !MediaQuery.of(context).disableAnimations;
 
     // Update the disc center for rotation detection
     _rotationRecognizer.discCenter = () =>
@@ -464,30 +526,10 @@ class _AlbumArtBoxState extends State<AlbumArtBox>
                               borderRadius: BorderRadius.circular(
                                 artInnerRadius,
                               ),
-                              child: CachedImageWidget(
-                                imagePath: widget.song.albumArt,
-                                audioSourcePath: widget.song.filePath,
-                                fit: BoxFit.cover,
-                                placeholder: Container(
-                                  color: Colors.white.withValues(alpha: 0.05),
-                                  child: Transform.translate(
-                                    offset: Offset(0, 6 * (1 - t)),
-                                    child: FlickArtworkPlaceholder(
-                                      size: iconSize * (1 - t * 0.5) * 1.42,
-                                      opacity: 0.92,
-                                    ),
-                                  ),
-                                ),
-                                errorWidget: Container(
-                                  color: Colors.white.withValues(alpha: 0.05),
-                                  child: Transform.translate(
-                                    offset: Offset(0, 6 * (1 - t)),
-                                    child: FlickArtworkPlaceholder(
-                                      size: iconSize * (1 - t * 0.5) * 1.42,
-                                      opacity: 0.92,
-                                    ),
-                                  ),
-                                ),
+                              child: _buildArtContent(
+                                iconSize: iconSize,
+                                t: t,
+                                motionEnabled: motionEnabled,
                               ),
                             ),
                           )
@@ -496,30 +538,10 @@ class _AlbumArtBoxState extends State<AlbumArtBox>
                             child: SizedBox(
                               width: artSize,
                               height: artSize,
-                              child: CachedImageWidget(
-                                imagePath: widget.song.albumArt,
-                                audioSourcePath: widget.song.filePath,
-                                fit: BoxFit.cover,
-                                placeholder: Container(
-                                  color: Colors.white.withValues(alpha: 0.05),
-                                  child: Transform.translate(
-                                    offset: Offset(0, 6 * (1 - t)),
-                                    child: FlickArtworkPlaceholder(
-                                      size: iconSize * (1 - t * 0.5) * 1.42,
-                                      opacity: 0.92,
-                                    ),
-                                  ),
-                                ),
-                                errorWidget: Container(
-                                  color: Colors.white.withValues(alpha: 0.05),
-                                  child: Transform.translate(
-                                    offset: Offset(0, 6 * (1 - t)),
-                                    child: FlickArtworkPlaceholder(
-                                      size: iconSize * (1 - t * 0.5) * 1.42,
-                                      opacity: 0.92,
-                                    ),
-                                  ),
-                                ),
+                              child: _buildArtContent(
+                                iconSize: iconSize,
+                                t: t,
+                                motionEnabled: motionEnabled,
                               ),
                             ),
                           ),

--- a/lib/features/player/widgets/motion_art_widget.dart
+++ b/lib/features/player/widgets/motion_art_widget.dart
@@ -1,0 +1,222 @@
+import 'dart:async';
+
+import 'package:flick/core/utils/dev_log.dart';
+import 'package:flick/services/motion_art/animated_artwork_service.dart';
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+
+/// Renders Apple Music Motion Art for an album while falling back to [fallback]
+/// (typically the Ken Burns [AnimatedAlbumArt] or a static artwork widget).
+///
+/// Controllers are always created with [VideoPlayerOptions.mixWithOthers] so
+/// ExoPlayer never requests audio focus and playback of the actual music via
+/// just_audio is not interrupted.
+class MotionArtView extends StatefulWidget {
+  const MotionArtView({
+    super.key,
+    required this.title,
+    required this.artist,
+    required this.fallback,
+    this.album,
+    this.duration,
+    this.enabled = true,
+    this.albumMode = false,
+    this.representativeSongTitle,
+    this.fit = BoxFit.cover,
+    this.borderRadius,
+  });
+
+  /// Song title, or the album name when [albumMode] is true.
+  final String title;
+  final String artist;
+  final String? album;
+  final Duration? duration;
+
+  /// Always rendered when no video is available or [enabled] is false.
+  final Widget fallback;
+
+  final bool enabled;
+
+  /// Resolve by album (edition-aware) rather than by song.
+  final bool albumMode;
+  final String? representativeSongTitle;
+
+  final BoxFit fit;
+  final BorderRadius? borderRadius;
+
+  @override
+  State<MotionArtView> createState() => _MotionArtViewState();
+}
+
+class _MotionArtViewState extends State<MotionArtView> {
+  static const Duration _debounce = Duration(milliseconds: 120);
+  static const Duration _retryDelay = Duration(seconds: 35);
+  static const int _maxAttempts = 4;
+
+  VideoPlayerController? _controller;
+  bool _hasVideo = false;
+  Timer? _timer;
+  Timer? _retryTimer;
+  int _generation = 0;
+  int _attempt = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _restart();
+  }
+
+  @override
+  void didUpdateWidget(covariant MotionArtView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final changed =
+        oldWidget.title != widget.title ||
+        oldWidget.artist != widget.artist ||
+        oldWidget.album != widget.album ||
+        oldWidget.albumMode != widget.albumMode ||
+        oldWidget.representativeSongTitle != widget.representativeSongTitle ||
+        oldWidget.enabled != widget.enabled;
+    if (changed) _restart();
+  }
+
+  @override
+  void dispose() {
+    _teardown();
+    super.dispose();
+  }
+
+  void _teardown() {
+    _generation++;
+    _timer?.cancel();
+    _timer = null;
+    _retryTimer?.cancel();
+    _retryTimer = null;
+    _hasVideo = false;
+    final controller = _controller;
+    _controller = null;
+    controller?.dispose();
+  }
+
+  void _restart() {
+    _teardown();
+    _attempt = 0;
+    _beginLoad();
+  }
+
+  void _beginLoad() {
+    if (!widget.enabled) return;
+    final generation = _generation;
+    _timer = Timer(_debounce, () => _loadOnce(generation));
+  }
+
+  void _scheduleRetry() {
+    if (!widget.enabled || _attempt >= _maxAttempts) return;
+    _attempt++;
+    _retryTimer?.cancel();
+    _retryTimer = Timer(_retryDelay, () {
+      if (!mounted) return;
+      _beginLoad();
+    });
+  }
+
+  Future<void> _loadOnce(int generation) async {
+    AnimatedArtwork? artwork;
+    try {
+      final service = AnimatedArtworkService.instance;
+      if (widget.albumMode) {
+        artwork = await service.getAnimatedArtworkForAlbum(
+          albumName: widget.album ?? widget.title,
+          artist: widget.artist,
+          representativeSongTitle: widget.representativeSongTitle,
+        );
+      } else {
+        artwork = await service.getAnimatedArtwork(
+          songTitle: widget.title,
+          artist: widget.artist,
+          albumName: widget.album,
+          duration: widget.duration,
+        );
+      }
+    } catch (error) {
+      devLog('[MotionArt] lookup failed: $error');
+    }
+
+    if (!mounted || generation != _generation) return;
+    final url = artwork?.playbackUrl;
+    if (url == null) {
+      // Could be a definitive "no motion art" (cache hit, no network) or a
+      // transient boidu 503; a bounded retry covers the transient case and is
+      // cheap for the definitive case because the negative is cached.
+      _scheduleRetry();
+      return;
+    }
+
+    VideoPlayerController? controller;
+    try {
+      final uri = Uri.parse(url);
+      controller = VideoPlayerController.networkUrl(
+        uri,
+        // boidu's `animated` field is an Apple HLS playlist; hinting the format
+        // is more robust than relying on ExoPlayer's URI-extension sniffing.
+        formatHint: uri.path.toLowerCase().endsWith('.m3u8')
+            ? VideoFormat.hls
+            : null,
+        videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true),
+      );
+      await controller.initialize();
+      await controller.setLooping(true);
+      await controller.setVolume(0);
+      if (!mounted || generation != _generation) {
+        await controller.dispose();
+        return;
+      }
+      await controller.play();
+    } catch (error) {
+      devLog('[MotionArt] video init failed: $error');
+      await controller?.dispose();
+      _scheduleRetry();
+      return;
+    }
+
+    if (!mounted || generation != _generation) {
+      await controller.dispose();
+      return;
+    }
+
+    final previous = _controller;
+    setState(() {
+      _controller = controller;
+      _hasVideo = true;
+    });
+    _attempt = 0;
+    await previous?.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = _controller;
+    if (!_hasVideo || controller == null || !controller.value.isInitialized) {
+      return widget.fallback;
+    }
+
+    final size = controller.value.size;
+    if (size.width <= 0 || size.height <= 0) return widget.fallback;
+
+    Widget video = SizedBox.expand(
+      child: FittedBox(
+        fit: widget.fit,
+        clipBehavior: Clip.hardEdge,
+        child: SizedBox(
+          width: size.width,
+          height: size.height,
+          child: VideoPlayer(controller),
+        ),
+      ),
+    );
+    final radius = widget.borderRadius;
+    if (radius != null) {
+      video = ClipRRect(borderRadius: radius, child: video);
+    }
+    return video;
+  }
+}

--- a/lib/features/settings/screens/ui_customization_settings_screen.dart
+++ b/lib/features/settings/screens/ui_customization_settings_screen.dart
@@ -164,7 +164,7 @@ class UiCustomizationSettingsScreen extends ConsumerWidget {
                 icon: LucideIcons.sparkles,
                 title: 'Animated Album Art',
                 subtitle:
-                    'Pan/zoom, ambient glow and smooth fade on album, artist and playlist heroes',
+                    'Apple Music Motion Art on albums plus pan/zoom, ambient glow and smooth fade on heroes',
                 value: appPreferences.animatedAlbumArt,
                 onChanged: (value) {
                   ref

--- a/lib/features/whats_new/data/changelog_data.dart
+++ b/lib/features/whats_new/data/changelog_data.dart
@@ -44,6 +44,94 @@ class ChangelogSubsection {
 /// automatically surface the entry whose `version` equals `kAppVersion`.
 const List<ChangelogEntry> kChangelogEntries = [
   ChangelogEntry(
+    version: '0.22.0-beta.1',
+    date: '2026-09-10',
+    sections: [
+      ChangelogSection(
+        title: 'DSD Native Playback',
+        bullets: [
+          '**DSD-NATIVE output** via SAS offload shim (HiBy devices) with ALSA direct fallback.',
+          'DoP packer bit-reversal; short reads handled; wire silence padding fixes audio pops.',
+          'DSD wire format and grouping settings in UAC2 preferences; restored output mode and transport overrides.',
+          'DSD reconciliation finds unindexed DSD files; decoder crash dumps captured offline.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'ReplayGain & Crossfeed',
+        bullets: [
+          '**ReplayGain** Track/Album modes with pre-amp and clipping prevention.',
+          'Scanner analyzes loudness (EBU R128 / BS.1770), writes `REPLAYGAIN_*` tags, and updates the library.',
+          '**BS2B crossfeed** with Default/strong/gentle presets; persists across engine recreation; bypassed on bit-perfect.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Karaoke Lyrics',
+        bullets: [
+          'Word-level **karaoke sync** with gradient sweep and a toggle in lyrics settings.',
+          'Full-screen **Lyrics Sync Studio**: tap-along word stamping, enhanced LRC export, video-style word timeline, syllable splitting.',
+          'Lyrics from **MP4/M4A and OGG/Opus** containers; text alignment options and readability scrim.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Global Search',
+        bullets: [
+          'Unified search across songs, albums, artists, and playlists.',
+          'Filter chips with persisted selection; refined search screen.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Smarter Library Scanning',
+        bullets: [
+          'Optional **Full Library Access** — Rust scanner walks every volume directly; falls back to MediaStore/SAF.',
+          '**DSD/DSF/WavPack always scanned**, even on devices whose media indexer skips them (Xiaomi/MIUI, Vivo, Honor).',
+          '**WavPack/DSD tags & album art everywhere** via Rust parser fallback; fixed DFF/WavPack embedded covers.',
+          '**Fixed library wipe when switching scan engines** — each engine only deletes rows it can see.',
+          'Floating minimizable scan progress pill; preload runs as one cancellable pass with a Stop button.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Engine Recovery & Accuracy',
+        bullets: [
+          'Rust engine **crash recovery** — revives on dead channels with panic reporting.',
+          'Lying container headers detected and corrected; implausible sample rates filtered.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Navigation & UI Refresh',
+        bullets: [
+          'Nested navigators per tab; full player and queue routed via root navigator.',
+          'New **FlickDialog** system and **FlickArtworkPlaceholder** across the app.',
+          'Shared detail headers with glass blur back buttons; landscape mode support.',
+          'System **reduced-motion** preference respected globally.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'USB & Bluetooth',
+        bullets: [
+          'Bit-perfect **auto-prompt on DAC attach**, with per-device decline memory.',
+          'UAC1: refuses direct USB when SET_CUR fails; better sampling-frequency negotiation.',
+          'USB route monitoring at boot; Hi-Res Direct for the Bluetooth Rust Oboe path.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Network Sources',
+        bullets: [
+          'Jellyfin **silent re-auth** via secure password store; auth failure detection.',
+          'Tidal sign-in fix with persisted session token.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Player & Library',
+        bullets: [
+          'Rebuilt full player with song stage carousel; swipe-down previous-track gesture.',
+          'Metadata editor moved to a bottom sheet with instant sync.',
+          'Playlist sorting; bulk favorites; duplicate cleaner with per-group multi-keep.',
+          'EQ knobs: double-tap to reset.',
+        ],
+      ),
+    ],
+  ),
+  ChangelogEntry(
     version: '0.21.0-beta.1',
     date: '2026-07-10',
     sections: [

--- a/lib/services/album_art_service.dart
+++ b/lib/services/album_art_service.dart
@@ -34,6 +34,10 @@ class AlbumArtService {
   final MusicFolderService _musicFolderService = MusicFolderService();
   final Map<String, Future<String?>> _inFlightResolutions = {};
 
+  // ponytail: album tracks share one folder cover; cache the raw bytes so a
+  // 20-track album reads cover.jpg once, not 20 times.
+  final Map<String, Uint8List?> _folderCoverCache = {};
+
   Future<String?> resolveArtworkPath({
     String? existingPath,
     required String audioSourcePath,
@@ -180,7 +184,8 @@ class AlbumArtService {
 
   /// Fetch raw artwork bytes. Network songs resolve through their protocol
   /// service's cover endpoint using the `<proto>-cover://<marker>` stored in
-  /// the entity's albumArtPath; local songs extract embedded art as before.
+  /// the entity's albumArtPath. Local songs try embedded art first, then fall
+  /// back to a nearby folder cover (`cover.jpg`, `folder.png`, …).
   Future<Uint8List?> _loadArtworkBytes(
     String audioSourcePath, {
     String? existingPath,
@@ -207,6 +212,16 @@ class AlbumArtService {
       }
     }
 
+    final embedded = await _loadEmbeddedArtworkBytes(audioSourcePath);
+    if (embedded != null && embedded.isNotEmpty) {
+      return embedded;
+    }
+
+    // No embedded cover: many libraries ship a sibling cover/folder image.
+    return _loadFolderCoverBytes(audioSourcePath);
+  }
+
+  Future<Uint8List?> _loadEmbeddedArtworkBytes(String audioSourcePath) async {
     if (Platform.isAndroid && audioSourcePath.startsWith('content://')) {
       // MediaMetadataRetriever cannot decode WavPack/DSD covers on any
       // device; route those through the Rust parser via the shared staging
@@ -236,6 +251,63 @@ class AlbumArtService {
     return rust_scanner.extractEmbeddedArtwork(
       path: _plainPathOf(audioSourcePath),
     );
+  }
+
+  /// Bounded memory cache for per-folder cover bytes.
+  static const int _folderCoverCacheMaxEntries = 64;
+
+  Future<Uint8List?> _loadFolderCoverBytes(String audioSourcePath) async {
+    if (audioSourcePath.startsWith('content://')) {
+      if (!Platform.isAndroid) return null;
+      try {
+        return await _musicFolderService.fetchSiblingArtwork(audioSourcePath);
+      } catch (_) {
+        return null;
+      }
+    }
+
+    final plainPath = _plainPathOf(audioSourcePath);
+    final dir = File(plainPath).parent.path;
+    if (_folderCoverCache.containsKey(dir)) {
+      return _folderCoverCache[dir];
+    }
+
+    final bytes = await _readFolderCoverFromFilesystem(plainPath);
+    _rememberFolderCover(dir, bytes);
+    return bytes;
+  }
+
+  void _rememberFolderCover(String dir, Uint8List? bytes) {
+    if (_folderCoverCache.length >= _folderCoverCacheMaxEntries) {
+      _folderCoverCache.remove(_folderCoverCache.keys.first);
+    }
+    _folderCoverCache[dir] = bytes;
+  }
+
+  Future<Uint8List?> _readFolderCoverFromFilesystem(String audioPath) async {
+    if (audioPath.isEmpty) return null;
+    final parent = File(audioPath).parent;
+    if (!await parent.exists()) return null;
+
+    final matches = <File>[];
+    try {
+      await for (final entity in parent.list(followLinks: false)) {
+        if (entity is! File) continue;
+        final name = entity.uri.pathSegments.last.toLowerCase();
+        if (!isFolderCoverImageName(name)) continue;
+        matches.add(entity);
+      }
+    } catch (_) {
+      return null;
+    }
+    if (matches.isEmpty) return null;
+
+    matches.sort((a, b) => a.path.compareTo(b.path));
+    try {
+      return await matches.first.readAsBytes();
+    } catch (_) {
+      return null;
+    }
   }
 
   /// Extensions whose embedded art only the Rust parsers can read.
@@ -299,6 +371,38 @@ class AlbumArtService {
 const int _artworkMaxDimension = 1000;
 const int _artworkPassthroughBytes = 512 * 1024;
 const int _artworkJpegQuality = 85;
+
+/// Sibling cover stems, matching the SMB/WebDAV scanners so local folders
+/// behave the same.
+const List<String> _folderCoverStems = [
+  'cover',
+  'folder',
+  'album',
+  'albumart',
+  'front',
+];
+
+const Set<String> _folderCoverExtensions = {
+  'jpg',
+  'jpeg',
+  'png',
+  'webp',
+  'gif',
+  'bmp',
+};
+
+/// Whether [name] looks like a folder-cover image: `cover.jpg`, `folder.png`,
+/// `front.webp`, `album.1.jpg`, …. Case-insensitive.
+bool isFolderCoverImageName(String name) {
+  final lower = name.toLowerCase();
+  final dot = lower.lastIndexOf('.');
+  if (dot <= 0) return false;
+  final stem = lower.substring(0, dot);
+  if (!_folderCoverExtensions.contains(lower.substring(dot + 1))) {
+    return false;
+  }
+  return _folderCoverStems.any((c) => stem == c || stem.startsWith('$c.'));
+}
 
 Uint8List _normalizeArtworkIsolate(Uint8List raw) {
   if (raw.length < _artworkPassthroughBytes) {

--- a/lib/services/motion_art/animated_artwork_service.dart
+++ b/lib/services/motion_art/animated_artwork_service.dart
@@ -1,0 +1,503 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flick/core/utils/dev_log.dart';
+import 'package:flick/services/motion_art/motion_art_album_matcher.dart';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+
+/// An Apple Music "Motion Art" record returned by the public boidu.dev proxy.
+class AnimatedArtwork {
+  const AnimatedArtwork({
+    required this.name,
+    required this.artist,
+    required this.albumId,
+    this.staticUrl,
+    this.animatedUrl,
+    this.animatedVerticalUrl,
+    this.videoUrl,
+    this.videoUrlVertical,
+  });
+
+  final String name;
+  final String artist;
+  final String albumId;
+  final String? staticUrl;
+
+  /// HLS playlist (preferred: adaptive, streams instantly).
+  final String? animatedUrl;
+  final String? animatedVerticalUrl;
+
+  /// Progressive mp4. boidu serves a 2160x2160 file, so this is never
+  /// downloaded up-front — it is only a last-resort stream source.
+  final String? videoUrl;
+  final String? videoUrlVertical;
+
+  static bool _has(String? s) => s != null && s.trim().isNotEmpty;
+
+  bool get hasMotion =>
+      _has(animatedUrl) ||
+      _has(videoUrl) ||
+      _has(animatedVerticalUrl) ||
+      _has(videoUrlVertical);
+
+  /// Best URL to feed [VideoPlayerController]: HLS before 4K mp4.
+  String? get playbackUrl {
+    for (final url in [
+      animatedUrl,
+      videoUrl,
+      animatedVerticalUrl,
+      videoUrlVertical,
+    ]) {
+      if (_has(url)) return url;
+    }
+    return null;
+  }
+
+  factory AnimatedArtwork.fromJson(Map<String, dynamic> json) {
+    String? str(Object? v) => v is String && v.trim().isNotEmpty ? v : null;
+    return AnimatedArtwork(
+      name: str(json['name']) ?? '',
+      artist: str(json['artist']) ?? '',
+      albumId: str(json['albumId']) ?? '',
+      staticUrl: str(json['static']),
+      animatedUrl: str(json['animated']),
+      animatedVerticalUrl: str(json['animatedVertical']),
+      videoUrl: str(json['videoUrl']),
+      videoUrlVertical: str(json['videoUrlVertical']),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    'artist': artist,
+    'albumId': albumId,
+    if (staticUrl != null) 'static': staticUrl,
+    if (animatedUrl != null) 'animated': animatedUrl,
+    if (animatedVerticalUrl != null) 'animatedVertical': animatedVerticalUrl,
+    if (videoUrl != null) 'videoUrl': videoUrl,
+    if (videoUrlVertical != null) 'videoUrlVertical': videoUrlVertical,
+  };
+}
+
+class _CacheEntry {
+  const _CacheEntry({required this.artwork, required this.expiresAtMs});
+  final AnimatedArtwork? artwork;
+  final int expiresAtMs;
+}
+
+/// Thrown when a lookup failed for a reason that may succeed later (timeout,
+/// network error, boidu 429/503). These are cached briefly, never for 6h.
+class _MotionArtTransientException implements Exception {
+  const _MotionArtTransientException(this.message);
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// Fetches Apple Music Motion Art (animated album artwork) from the public
+/// boidu.dev proxy.
+///
+/// No token is required. The correct Apple collection id is resolved through
+/// the iTunes Search API first so edition qualifiers survive (e.g.
+/// "Fearless (Taylor's Version)" must never resolve to the original
+/// "Fearless"), then boidu is queried by `?id=`. Song-text search is only a
+/// fallback when the album is unknown or the id lookup misses.
+///
+/// Positive results are cached 24h, negative results 6h, both in memory and on
+/// disk, so albums without motion art are not re-queried on every launch.
+class AnimatedArtworkService {
+  AnimatedArtworkService._();
+  static final AnimatedArtworkService instance = AnimatedArtworkService._();
+
+  static const String _boiduBase = 'https://artwork.boidu.dev/';
+  static const String _itunesBase = 'https://itunes.apple.com/search';
+  static const String _userAgent =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36';
+  static const Duration _requestTimeout = Duration(seconds: 15);
+  static const Duration _positiveTtl = Duration(hours: 24);
+  static const Duration _negativeTtl = Duration(hours: 6);
+
+  /// Transient failures (timeouts, 503s) are retried soon instead of being
+  /// cached as "no artwork" for the full negative TTL.
+  static const Duration _transientTtl = Duration(seconds: 30);
+  static const int _itunesLimit = 25;
+
+  /// boidu rate-limits its upstream, so cap concurrent requests.
+  static const int _boiduMaxConcurrent = 2;
+
+  final Map<String, _CacheEntry> _mem = {};
+  final Map<String, Future<AnimatedArtwork?>> _inflight = {};
+
+  int _boiduActive = 0;
+  final List<Completer<void>> _boiduWaiters = [];
+
+  /// Motion art for a playing song. Album metadata takes priority so the right
+  /// edition is resolved; the song title is only used as a fallback.
+  Future<AnimatedArtwork?> getAnimatedArtwork({
+    required String songTitle,
+    required String artist,
+    String? albumName,
+    Duration? duration,
+    String storefront = 'us',
+  }) {
+    final album = albumName?.trim() ?? '';
+    final key = _cacheKey(
+      'song:${songTitle.trim()}',
+      artist,
+      album,
+      storefront,
+    );
+    return _resolve(
+      key,
+      () => _resolveFromAlbumOrSong(
+        songTitle: songTitle,
+        artist: artist,
+        albumName: album,
+        storefront: storefront,
+      ),
+    );
+  }
+
+  /// Motion art for an album hero. Album-first so the edition is preserved.
+  Future<AnimatedArtwork?> getAnimatedArtworkForAlbum({
+    required String albumName,
+    required String artist,
+    String? representativeSongTitle,
+    String storefront = 'us',
+  }) {
+    final key = _cacheKey('album:${albumName.trim()}', artist, '', storefront);
+    return _resolve(
+      key,
+      () async {
+        final byAlbum = await _resolveAlbum(albumName, artist, storefront);
+        if (byAlbum != null) return byAlbum;
+        final song = representativeSongTitle?.trim() ?? '';
+        if (song.isEmpty) return null;
+        return _fetchBoiduSong(
+          songTitle: song,
+          artist: artist,
+          albumName: albumName,
+          storefront: storefront,
+        );
+      },
+    );
+  }
+
+  Future<AnimatedArtwork?> _resolveFromAlbumOrSong({
+    required String songTitle,
+    required String artist,
+    required String albumName,
+    required String storefront,
+  }) async {
+    if (albumName.isNotEmpty) {
+      final byAlbum = await _resolveAlbum(albumName, artist, storefront);
+      if (byAlbum != null) return byAlbum;
+    }
+    return _fetchBoiduSong(
+      songTitle: songTitle,
+      artist: artist,
+      albumName: albumName.isEmpty ? null : albumName,
+      storefront: storefront,
+    );
+  }
+
+  /// iTunes collection id -> boidu `?id=`, then a validated text fallback.
+  Future<AnimatedArtwork?> _resolveAlbum(
+    String album,
+    String artist,
+    String storefront,
+  ) async {
+    final collectionId = await _resolveCollectionId(album, artist, storefront);
+    if (collectionId != null) {
+      final art = await _fetchBoiduById(collectionId);
+      if (art != null && art.hasMotion) return art;
+    }
+    return _fetchBoiduAlbumText(album, artist, storefront);
+  }
+
+  Future<String?> _resolveCollectionId(
+    String album,
+    String artist,
+    String storefront,
+  ) async {
+    final storefronts = <String>[
+      storefront,
+      if (storefront != 'us') 'us',
+    ];
+    for (final sf in storefronts) {
+      try {
+        final uri = Uri.parse(_itunesBase).replace(
+          queryParameters: {
+            'term': '$artist $album',
+            'media': 'music',
+            'entity': 'album',
+            'limit': '$_itunesLimit',
+            'country': sf,
+          },
+        );
+        final response = await http
+            .get(uri, headers: {'User-Agent': _userAgent})
+            .timeout(_requestTimeout);
+        if (response.statusCode != 200) continue;
+        final decoded = jsonDecode(response.body);
+        if (decoded is! Map<String, dynamic>) continue;
+        final results = (decoded['results'] as List?)
+            ?.whereType<Map<String, dynamic>>()
+            .toList();
+        if (results == null || results.isEmpty) continue;
+        final id = MotionArtAlbumMatcher.pickCollectionId(
+          album: album,
+          artist: artist,
+          results: results,
+        );
+        if (id != null && id.isNotEmpty) return id;
+      } catch (error) {
+        devLog('[MotionArt] iTunes lookup "$artist - $album" ($sf): $error');
+      }
+    }
+    return null;
+  }
+
+  Future<AnimatedArtwork?> _fetchBoiduById(String collectionId) async {
+    try {
+      final uri = Uri.parse(
+        _boiduBase,
+      ).replace(queryParameters: {'id': collectionId});
+      final art = await _getBoidu(uri);
+      return (art != null && art.hasMotion) ? art : null;
+    } on _MotionArtTransientException catch (error) {
+      devLog('[MotionArt] boidu id $collectionId: $error');
+      rethrow;
+    } catch (error) {
+      devLog('[MotionArt] boidu id $collectionId failed: $error');
+      throw _MotionArtTransientException('$error');
+    }
+  }
+
+  Future<AnimatedArtwork?> _fetchBoiduAlbumText(
+    String album,
+    String artist,
+    String storefront,
+  ) async {
+    try {
+      final uri = Uri.parse(_boiduBase).replace(
+        queryParameters: {'s': album, 'a': artist, 'storefront': storefront},
+      );
+      final art = await _getBoidu(uri);
+      // A valid response with no motion is definitive: stop, don't retry.
+      if (art == null || !art.hasMotion) return null;
+      final name = art.name.isNotEmpty ? art.name : album;
+      if (!MotionArtAlbumMatcher.nameMatchesAlbum(
+        requested: album,
+        candidate: name,
+      )) {
+        devLog('[MotionArt] rejected edition mismatch: "$album" -> "$name"');
+        return null;
+      }
+      return art;
+    } on _MotionArtTransientException {
+      rethrow;
+    } catch (error) {
+      devLog('[MotionArt] boidu search "$artist - $album" ($storefront): $error');
+      throw _MotionArtTransientException('$error');
+    }
+  }
+
+  Future<AnimatedArtwork?> _fetchBoiduSong({
+    required String songTitle,
+    required String artist,
+    required String? albumName,
+    required String storefront,
+  }) async {
+    try {
+      final uri = Uri.parse(_boiduBase).replace(
+        queryParameters: {
+          's': songTitle,
+          'a': artist,
+          if (albumName != null && albumName.isNotEmpty) 'al': albumName,
+          'storefront': storefront,
+        },
+      );
+      final art = await _getBoidu(uri);
+      if (art == null || !art.hasMotion) return null;
+      // Guard against song-level lookups returning a different edition.
+      // Only strict when the album carries an edition qualifier; otherwise
+      // boidu may echo the song title instead of the album name.
+      final album = albumName;
+      if (album != null &&
+          album.isNotEmpty &&
+          art.name.isNotEmpty &&
+          MotionArtAlbumMatcher.editionTokens(album).isNotEmpty &&
+          !MotionArtAlbumMatcher.nameMatchesAlbum(
+            requested: album,
+            candidate: art.name,
+          )) {
+        devLog(
+          '[MotionArt] rejected song-level edition mismatch: '
+          '"$album" -> "${art.name}"',
+        );
+        return null;
+      }
+      return art;
+    } on _MotionArtTransientException {
+      rethrow;
+    } catch (error) {
+      devLog('[MotionArt] boidu song "$artist - $songTitle" ($storefront): $error');
+      throw _MotionArtTransientException('$error');
+    }
+  }
+
+  /// Runs [action] with at most [_boiduMaxConcurrent] boidu requests in flight.
+  Future<T> _withBoiduSlot<T>(Future<T> Function() action) async {
+    if (_boiduActive >= _boiduMaxConcurrent) {
+      final waiter = Completer<void>();
+      _boiduWaiters.add(waiter);
+      await waiter.future;
+    }
+    _boiduActive++;
+    try {
+      return await action();
+    } finally {
+      _boiduActive--;
+      if (_boiduWaiters.isNotEmpty) {
+        _boiduWaiters.removeAt(0).complete();
+      }
+    }
+  }
+
+  Future<AnimatedArtwork?> _getBoidu(Uri uri) {
+    return _withBoiduSlot(() async {
+      final http.Response response;
+      try {
+        response = await http
+            .get(uri, headers: {'User-Agent': _userAgent})
+            .timeout(_requestTimeout);
+      } on TimeoutException {
+        throw const _MotionArtTransientException('boidu request timed out');
+      } catch (error) {
+        throw _MotionArtTransientException('boidu network error: $error');
+      }
+      if (response.statusCode == 429 || response.statusCode == 503) {
+        throw const _MotionArtTransientException('boidu rate limited');
+      }
+      if (response.statusCode != 200) {
+        throw _MotionArtTransientException('boidu http ${response.statusCode}');
+      }
+      final decoded = jsonDecode(response.body);
+      if (decoded is! Map<String, dynamic>) return null;
+      if (decoded['error'] != null) return null;
+      final art = AnimatedArtwork.fromJson(decoded);
+      return art.hasMotion ? art : null;
+    });
+  }
+
+  /// Memory cache -> disk cache -> in-flight dedupe -> network.
+  Future<AnimatedArtwork?> _resolve(
+    String key,
+    Future<AnimatedArtwork?> Function() loader,
+  ) {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final cached = _mem[key];
+    if (cached != null && now < cached.expiresAtMs) {
+      return Future.value(cached.artwork);
+    }
+
+    final existing = _inflight[key];
+    if (existing != null) return existing;
+
+    final future = () async {
+      final disk = await _readDiskCache(key);
+      if (disk != null) {
+        _mem[key] = disk;
+        return disk.artwork;
+      }
+
+      AnimatedArtwork? artwork;
+      var transient = false;
+      try {
+        artwork = await loader();
+      } on _MotionArtTransientException catch (error) {
+        devLog('[MotionArt] transient "$key": $error');
+        transient = true;
+      } catch (error) {
+        devLog('[MotionArt] resolve "$key" failed: $error');
+        transient = true;
+      }
+
+      final hasMotion = artwork != null && artwork.hasMotion;
+      final ttl = hasMotion
+          ? _positiveTtl
+          : (transient ? _transientTtl : _negativeTtl);
+      final entry = _CacheEntry(
+        artwork: hasMotion ? artwork : null,
+        expiresAtMs: DateTime.now().millisecondsSinceEpoch +
+            ttl.inMilliseconds,
+      );
+      _mem[key] = entry;
+      // Only persist definitive outcomes; transient failures retry next launch.
+      if (!transient) unawaited(_writeDiskCache(key, entry));
+      return entry.artwork;
+    }();
+
+    _inflight[key] = future;
+    return future.whenComplete(() => _inflight.remove(key));
+  }
+
+  String _cacheKey(String prefix, String artist, String album, String sf) {
+    final raw = '$prefix|${artist.toLowerCase()}|'
+        '${album.toLowerCase()}|$sf';
+    return sha1.convert(utf8.encode(raw)).toString();
+  }
+
+  Future<Directory> _cacheDir() async {
+    final base = await getApplicationSupportDirectory();
+    final dir = Directory('${base.path}/motion_art');
+    if (!await dir.exists()) await dir.create(recursive: true);
+    return dir;
+  }
+
+  Future<_CacheEntry?> _readDiskCache(String key) async {
+    try {
+      final file = File('${(await _cacheDir()).path}/$key.json');
+      if (!await file.exists()) return null;
+      final decoded = jsonDecode(await file.readAsString());
+      if (decoded is! Map<String, dynamic>) return null;
+      final expiresAtMs = (decoded['expiresAtMs'] as num?)?.toInt() ?? 0;
+      if (DateTime.now().millisecondsSinceEpoch >= expiresAtMs) {
+        await file.delete();
+        return null;
+      }
+      final artJson = decoded['artwork'];
+      if (decoded['negative'] == true || artJson is! Map<String, dynamic>) {
+        return _CacheEntry(artwork: null, expiresAtMs: expiresAtMs);
+      }
+      final artwork = AnimatedArtwork.fromJson(artJson);
+      return _CacheEntry(
+        artwork: artwork.hasMotion ? artwork : null,
+        expiresAtMs: expiresAtMs,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _writeDiskCache(String key, _CacheEntry entry) async {
+    try {
+      final file = File('${(await _cacheDir()).path}/$key.json');
+      await file.writeAsString(
+        jsonEncode({
+          'expiresAtMs': entry.expiresAtMs,
+          'negative': entry.artwork == null,
+          if (entry.artwork != null) 'artwork': entry.artwork!.toJson(),
+        }),
+        flush: true,
+      );
+    } catch (error) {
+      devLog('[MotionArt] cache write failed: $error');
+    }
+  }
+}

--- a/lib/services/motion_art/motion_art_album_matcher.dart
+++ b/lib/services/motion_art/motion_art_album_matcher.dart
@@ -1,0 +1,144 @@
+/// Pure string/edition matching for Motion Art album resolution.
+///
+/// Extracted from [AnimatedArtworkService] so the tricky "Fearless vs
+/// Fearless (Taylor's Version)" style logic is unit-testable without network.
+class MotionArtAlbumMatcher {
+  MotionArtAlbumMatcher._();
+
+  /// Edition words that distinguish otherwise identical albums. Ordered by
+  /// specificity so multi-word phrases win before single words.
+  static const List<String> editionWords = [
+    'taylor s version',
+    'super deluxe',
+    'deluxe',
+    'expanded',
+    'remastered',
+    'remaster',
+    'remix',
+    'bonus',
+    'platinum',
+    'anniversary',
+    'edition',
+    'version',
+    'explicit',
+    'clean',
+    'live',
+    'acoustic',
+    'ep',
+    'single',
+  ];
+
+  static const Map<String, String> _diacritics = {
+    'á': 'a', 'à': 'a', 'â': 'a', 'ä': 'a', 'ã': 'a', 'å': 'a',
+    'é': 'e', 'è': 'e', 'ê': 'e', 'ë': 'e',
+    'í': 'i', 'ì': 'i', 'î': 'i', 'ï': 'i',
+    'ó': 'o', 'ò': 'o', 'ô': 'o', 'ö': 'o', 'õ': 'o',
+    'ú': 'u', 'ù': 'u', 'û': 'u', 'ü': 'u',
+    'ñ': 'n', 'ç': 'c',
+  };
+
+  /// Lowercase, strip diacritics/punctuation, collapse whitespace.
+  static String normalize(String s) {
+    var x = s.toLowerCase();
+    x = x.replaceAll('’', "'").replaceAll('‘', "'");
+    x = x.replaceAll('“', '"').replaceAll('”', '"');
+    x = x.replaceAll(RegExp('[\u2013\u2014]'), ' ');
+    for (final entry in _diacritics.entries) {
+      x = x.replaceAll(entry.key, entry.value);
+    }
+    x = x.replaceAll(RegExp(r'[^a-z0-9]+'), ' ');
+    x = x.replaceAll(RegExp(r'\s+'), ' ').trim();
+    return x;
+  }
+
+  /// The album name with edition qualifiers and bracketed suffixes removed,
+  /// e.g. `"Fearless (Taylor's Version)"` -> `"fearless"`.
+  static String baseName(String s) {
+    var x = s.toLowerCase();
+    x = x.replaceAll(RegExp(r'\([^)]*\)'), ' ');
+    x = x.replaceAll(RegExp(r'\[[^\]]*\]'), ' ');
+    x = normalize(x);
+    final parts = x
+        .split(' ')
+        .where((p) => p.isNotEmpty && !editionWords.contains(p));
+    return parts.join(' ').trim();
+  }
+
+  /// Canonical edition tokens present in [s].
+  static Set<String> editionTokens(String s) {
+    final x = normalize(s);
+    final out = <String>{};
+    for (final word in editionWords) {
+      // `normalize` already turned apostrophes into spaces, so the phrase is
+      // matched as space-separated words.
+      if (RegExp('\\b${word.replaceAll(' ', r'\s+')}\\b').hasMatch(x)) {
+        out.add(word);
+      }
+    }
+    return out;
+  }
+
+  /// Whether the requested edition is fully satisfied by [candidate].
+  static bool nameMatchesAlbum({
+    required String requested,
+    required String candidate,
+  }) {
+    final reqNorm = normalize(requested);
+    final candNorm = normalize(candidate);
+    if (reqNorm == candNorm) return true;
+    if (baseName(requested) != baseName(candidate)) return false;
+    final reqTokens = editionTokens(requested);
+    final candTokens = editionTokens(candidate);
+    // Every requested edition qualifier must survive; a plain request accepts
+    // any edition of the same base album.
+    return reqTokens.every(candTokens.contains);
+  }
+
+  /// Loose artist comparison that tolerates `feat.`, `&`, and local variants.
+  static bool artistMatches(String requested, String candidate) {
+    final req = normalize(requested);
+    if (req.isEmpty) return true;
+    final cand = normalize(candidate);
+    if (cand.isEmpty) return false;
+    if (cand == req || cand.contains(req) || req.contains(cand)) return true;
+    final reqTokens = req.split(' ').toSet();
+    final candTokens = cand.split(' ').toSet();
+    final overlap = reqTokens.intersection(candTokens).length;
+    final slack = reqTokens.length <= 2 ? 0 : 1;
+    return overlap >= reqTokens.length - slack;
+  }
+
+  /// Pick the best iTunes `collectionId` for [album]/[artist] from search
+  /// [results], preserving editions. Returns null when nothing scores.
+  static String? pickCollectionId({
+    required String album,
+    required String artist,
+    required List<Map<String, dynamic>> results,
+  }) {
+    final reqBase = baseName(album);
+    if (reqBase.isEmpty) return null;
+    final reqTokens = editionTokens(album);
+    String? bestId;
+    var bestScore = 0; // require a positive score
+    for (final r in results) {
+      final cName = (r['collectionName'] as String?) ?? '';
+      final aName = (r['artistName'] as String?) ?? '';
+      if (!artistMatches(artist, aName)) continue;
+      if (baseName(cName) != reqBase) continue;
+      var score = 30;
+      final candTokens = editionTokens(cName);
+      for (final token in reqTokens) {
+        // Missing a qualifier the user asked for is the worst signal.
+        score += candTokens.contains(token) ? 6 : -10;
+      }
+      for (final token in candTokens) {
+        if (!reqTokens.contains(token)) score -= 3;
+      }
+      if (score > bestScore) {
+        bestScore = score;
+        bestId = r['collectionId']?.toString();
+      }
+    }
+    return bestId;
+  }
+}

--- a/lib/services/music_folder_service.dart
+++ b/lib/services/music_folder_service.dart
@@ -435,6 +435,19 @@ class MusicFolderService {
     }
   }
 
+  /// Reads a folder-cover image (cover.jpg, folder.png, …) sitting next to
+  /// [uri]. Needed for SAF `content://` sources, whose sibling files dart:io
+  /// cannot enumerate. Returns null when no cover exists.
+  Future<Uint8List?> fetchSiblingArtwork(String uri) async {
+    try {
+      return await _channel.invokeMethod<Uint8List>('readSiblingArtwork', {
+        'uri': uri,
+      });
+    } on PlatformException catch (e) {
+      throw StorageException('Failed to fetch sibling artwork: ${e.message}');
+    }
+  }
+
   /// Stages a content URI into the shared playback cache and returns the
   /// absolute staged path. [maxSizeBytes] optionally refuses to copy
   /// oversized sources (returns null) — used by metadata enrichment, not

--- a/lib/widgets/common/animated_album_art.dart
+++ b/lib/widgets/common/animated_album_art.dart
@@ -1,15 +1,25 @@
 import 'package:flutter/material.dart';
 
+import 'package:flick/features/player/widgets/motion_art_widget.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 
 /// Apple Music-style hero art: slow Ken Burns pan/zoom with a soft
 /// pulsing glow derived from the art's dominant color.
+///
+/// When [albumName] and [artistName] are supplied (album detail heroes), real
+/// Apple Music Motion Art is played instead, falling back to the Ken Burns
+/// effect whenever no motion art exists for the album.
 class AnimatedAlbumArt extends StatefulWidget {
   final String? imagePath;
   final String? audioSourcePath;
   final Color? dominantColor;
   final Widget? placeholder;
   final Widget? errorWidget;
+
+  /// Album metadata enabling the edition-aware Motion Art lookup.
+  final String? albumName;
+  final String? artistName;
+  final String? representativeSongTitle;
 
   const AnimatedAlbumArt({
     super.key,
@@ -18,6 +28,9 @@ class AnimatedAlbumArt extends StatefulWidget {
     this.dominantColor,
     this.placeholder,
     this.errorWidget,
+    this.albumName,
+    this.artistName,
+    this.representativeSongTitle,
   });
 
   @override
@@ -60,7 +73,7 @@ class _AnimatedAlbumArtState extends State<AnimatedAlbumArt>
       placeholder: widget.placeholder,
       errorWidget: widget.errorWidget,
     );
-    return ClipRect(
+    final kenBurns = ClipRect(
       child: AnimatedBuilder(
         animation: _controller,
         builder: (context, child) {
@@ -93,6 +106,20 @@ class _AnimatedAlbumArtState extends State<AnimatedAlbumArt>
         },
         child: image,
       ),
+    );
+
+    final album = widget.albumName?.trim() ?? '';
+    final artist = widget.artistName?.trim() ?? '';
+    if (album.isEmpty || artist.isEmpty) return kenBurns;
+
+    return MotionArtView(
+      title: album,
+      album: album,
+      artist: artist,
+      albumMode: true,
+      representativeSongTitle: widget.representativeSongTitle,
+      enabled: !MediaQuery.of(context).disableAnimations,
+      fallback: kenBurns,
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -249,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -578,6 +586,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "43b67b8f43321ab066817dfac5619596c98bb1b61624e77203bb4351785f9699"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.7"
   http:
     dependency: "direct main"
     description:
@@ -1579,6 +1595,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
+  video_player:
+    dependency: "direct main"
+    description:
+      name: video_player
+      sha256: "8c837b570dccb9ae6ff73d2e0b03c7e708bfefd3bd1194faa7f3e7f200dfc399"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.14.0"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      sha256: d27054dea34d748a44f06d433a57005d2aac69944485b0abbaed3303dbcfa3f1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.12.2"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      sha256: "2fc56e537324a19eb649fca991aa308ac961b5406292876fa657b062de461fd8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.12.0"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      sha256: "92c0fbabe20c788e71fd10d26cea998d0d253282e65d145aed0818731cf593ce"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.9.0"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:
@@ -1684,5 +1740,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.11.0-0 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   share_plus: ^10.1.4
   skeletonizer: ^2.1.2
   url_launcher: ^6.3.2
+  video_player: ^2.9.5
   xml: ^6.5.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.21.0-beta.1+26
+version: 0.22.0-beta.1+27
 
 environment:
   sdk: ^3.10.4

--- a/rust_builder/android/build.gradle
+++ b/rust_builder/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
     dependencies {
         // The Android Gradle Plugin knows how to build native code with the NDK.
-        classpath 'com.android.tools.build:gradle:8.11.1'
+        classpath 'com.android.tools.build:gradle:9.1.0'
     }
 }
 
@@ -26,7 +26,7 @@ android {
 
     // Bumping the plugin compileSdkVersion requires all clients of this plugin
     // to bump the version in their app.
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     // Use the NDK version
     // declared in /android/app/build.gradle file of the Flutter project.

--- a/rust_builder/cargokit/gradle/plugin.gradle
+++ b/rust_builder/cargokit/gradle/plugin.gradle
@@ -2,7 +2,9 @@
 /// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
 
 import java.nio.file.Paths
+import javax.inject.Inject
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
 
 CargoKitPlugin.file = buildscript.sourceFile
 
@@ -14,6 +16,9 @@ class CargoKitExtension {
 }
 
 abstract class CargoKitBuildTask extends DefaultTask {
+
+    @Inject
+    abstract ExecOperations getExecOperations()
 
     @Input
     String buildMode
@@ -60,12 +65,12 @@ abstract class CargoKitBuildTask extends DefaultTask {
         def rootProjectDir = project.rootProject.projectDir
 
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
-            project.exec {
+            execOperations.exec {
                 commandLine 'chmod', '+x', path
             }
         }
 
-        project.exec {
+        execOperations.exec {
             executable path
             args "build-gradle"
             environment "CARGOKIT_ROOT_PROJECT_DIR", rootProjectDir

--- a/test/features/onboarding/onboarding_screen_test.dart
+++ b/test/features/onboarding/onboarding_screen_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/features/onboarding/screens/onboarding_screen.dart';
+
+Future<void> _pumpOnboarding(WidgetTester tester) async {
+  SharedPreferences.setMockInitialValues({});
+  await tester.pumpWidget(
+    const ProviderScope(
+      child: MaterialApp(home: OnboardingScreen()),
+    ),
+  );
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+void main() {
+  tearDown(() => AppConstants.setAnimationsEnabled(true));
+
+  testWidgets('Next advances to the following page', (tester) async {
+    AppConstants.setAnimationsEnabled(true);
+    await _pumpOnboarding(tester);
+
+    expect(find.text('Welcome to\nFlick Player'), findsOneWidget);
+
+    await tester.tap(find.text('Next'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(find.text('Build Your\nLibrary'), findsOneWidget);
+  });
+
+  testWidgets('Next advances when animations are disabled', (tester) async {
+    AppConstants.setAnimationsEnabled(false);
+    await _pumpOnboarding(tester);
+
+    expect(find.text('Welcome to\nFlick Player'), findsOneWidget);
+
+    await tester.tap(find.text('Next'));
+    await tester.pump();
+
+    expect(find.text('Build Your\nLibrary'), findsOneWidget);
+  });
+}

--- a/test/services/album_art_service_test.dart
+++ b/test/services/album_art_service_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flick/services/album_art_service.dart';
+
+void main() {
+  group('isFolderCoverImageName', () {
+    test('accepts the classic cover/folder names', () {
+      expect(isFolderCoverImageName('cover.jpg'), isTrue);
+      expect(isFolderCoverImageName('folder.png'), isTrue);
+      expect(isFolderCoverImageName('album.webp'), isTrue);
+      expect(isFolderCoverImageName('albumart.jpeg'), isTrue);
+      expect(isFolderCoverImageName('front.gif'), isTrue);
+    });
+
+    test('is case-insensitive', () {
+      expect(isFolderCoverImageName('Cover.JPG'), isTrue);
+      expect(isFolderCoverImageName('FOLDER.Png'), isTrue);
+    });
+
+    test('accepts suffixed variants', () {
+      expect(isFolderCoverImageName('cover.front.jpg'), isTrue);
+      expect(isFolderCoverImageName('album.1.png'), isTrue);
+    });
+
+    test('rejects non-cover images', () {
+      expect(isFolderCoverImageName('back.jpg'), isFalse);
+      expect(isFolderCoverImageName('track.jpg'), isFalse);
+      expect(isFolderCoverImageName('cover.jpg.bak'), isFalse);
+    });
+
+    test('rejects non-image extensions', () {
+      expect(isFolderCoverImageName('cover.txt'), isFalse);
+      expect(isFolderCoverImageName('cover'), isFalse);
+    });
+  });
+}

--- a/test/services/motion_art_album_matcher_test.dart
+++ b/test/services/motion_art_album_matcher_test.dart
@@ -1,0 +1,173 @@
+import 'package:flick/services/motion_art/motion_art_album_matcher.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MotionArtAlbumMatcher.normalize', () {
+    test('lowercases, strips punctuation and accents', () {
+      expect(MotionArtAlbumMatcher.normalize('Beyoncé — Renaissance!'),
+          'beyonce renaissance');
+      expect(MotionArtAlbumMatcher.normalize("Taylor's Version"),
+          'taylor s version');
+    });
+  });
+
+  group('MotionArtAlbumMatcher.baseName', () {
+    test('drops parenthetical edition suffixes', () {
+      expect(
+        MotionArtAlbumMatcher.baseName("Fearless (Taylor's Version)"),
+        'fearless',
+      );
+      expect(
+        MotionArtAlbumMatcher.baseName('1989 (Deluxe Edition)'),
+        '1989',
+      );
+    });
+
+    test('drops trailing edition words', () {
+      expect(MotionArtAlbumMatcher.baseName('Fearless Deluxe'), 'fearless');
+    });
+  });
+
+  group('MotionArtAlbumMatcher.editionTokens', () {
+    test('detects the Taylor Version phrase', () {
+      expect(
+        MotionArtAlbumMatcher.editionTokens("Fearless (Taylor's Version)"),
+        contains('taylor s version'),
+      );
+    });
+
+    test('detects deluxe/remastered', () {
+      expect(
+        MotionArtAlbumMatcher.editionTokens('Abbey Road (Remastered)'),
+        contains('remastered'),
+      );
+    });
+
+    test('returns empty for a plain album', () {
+      expect(MotionArtAlbumMatcher.editionTokens('Random Access Memories'),
+          isEmpty);
+    });
+  });
+
+  group('MotionArtAlbumMatcher.nameMatchesAlbum', () {
+    test('rejects the original when Taylor Version is requested', () {
+      expect(
+        MotionArtAlbumMatcher.nameMatchesAlbum(
+          requested: "Fearless (Taylor's Version)",
+          candidate: 'Fearless',
+        ),
+        isFalse,
+      );
+    });
+
+    test('accepts the matching edition', () {
+      expect(
+        MotionArtAlbumMatcher.nameMatchesAlbum(
+          requested: "Fearless (Taylor's Version)",
+          candidate: "Fearless (Taylor's Version)",
+        ),
+        isTrue,
+      );
+    });
+
+    test('plain request accepts any edition of the same base album', () {
+      expect(
+        MotionArtAlbumMatcher.nameMatchesAlbum(
+          requested: '1989',
+          candidate: '1989 (Deluxe)',
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects a different album entirely', () {
+      expect(
+        MotionArtAlbumMatcher.nameMatchesAlbum(
+          requested: 'Red',
+          candidate: '1989',
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('MotionArtAlbumMatcher.pickCollectionId', () {
+    test('prefers the requested edition over the original', () {
+      final id = MotionArtAlbumMatcher.pickCollectionId(
+        album: "Fearless (Taylor's Version)",
+        artist: 'Taylor Swift',
+        results: const [
+          {
+            'collectionId': 1440924803,
+            'collectionName': 'Fearless',
+            'artistName': 'Taylor Swift',
+          },
+          {
+            'collectionId': 1552791073,
+            'collectionName': "Fearless (Taylor's Version)",
+            'artistName': 'Taylor Swift',
+          },
+        ],
+      );
+      expect(id, '1552791073');
+    });
+
+    test('plain request prefers the original over an edition', () {
+      final id = MotionArtAlbumMatcher.pickCollectionId(
+        album: 'Fearless',
+        artist: 'Taylor Swift',
+        results: const [
+          {
+            'collectionId': 1552791073,
+            'collectionName': "Fearless (Taylor's Version)",
+            'artistName': 'Taylor Swift',
+          },
+          {
+            'collectionId': 1440924803,
+            'collectionName': 'Fearless',
+            'artistName': 'Taylor Swift',
+          },
+        ],
+      );
+      expect(id, '1440924803');
+    });
+
+    test('ignores results by another artist', () {
+      final id = MotionArtAlbumMatcher.pickCollectionId(
+        album: 'Thriller',
+        artist: 'Michael Jackson',
+        results: const [
+          {
+            'collectionId': 1,
+            'collectionName': 'Thriller',
+            'artistName': 'Someone Else',
+          },
+        ],
+      );
+      expect(id, isNull);
+    });
+  });
+
+  group('MotionArtAlbumMatcher.artistMatches', () {
+    test('matches identical and prefixed names', () {
+      expect(
+        MotionArtAlbumMatcher.artistMatches('Taylor Swift', 'Taylor Swift'),
+        isTrue,
+      );
+      expect(
+        MotionArtAlbumMatcher.artistMatches(
+          'Taylor Swift',
+          'Taylor Swift feat. Brendon Urie',
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects unrelated artists', () {
+      expect(
+        MotionArtAlbumMatcher.artistMatches('Taylor Swift', 'Drake'),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Summary

- Add Apple Music Motion Art (animated album artwork): album-aware resolution, cache, and silent looping playback that never interrupts music
- Fall back to nearby/sibling folder covers when artwork is missing, for both SAF folders and local paths via a native sibling lookup
- Prefetch motion artwork on the Albums screen to avoid cold network waits
- Use exact page transitions in onboarding and test the navigation flow
- Prepare the `0.22.0-beta.1` pre-release and upgrade the Android build toolchain to AGP 9.1 / Gradle 9.3.1

# Changes

## Motion Art (Apple Music animated album art)

- New `motion_art_widget.dart` (222L): album-aware animated artwork playback with fetch retries and silent looping that doesn't interrupt music
- New `animated_artwork_service.dart` (503L): resolution + cache service for motion artwork (metadata + video), with tests
- New `motion_art_album_matcher.dart` (144L): extracts album-name/edition matching into a testable service — normalizes names, compares editions, tolerates artist variants, selects the best iTunes collection ID (173L of tests)
- Refactor `album_art_box.dart` to render via `MotionArtView`/`AnimatedAlbumArt`, respecting the animated album art preference and system animation settings while keeping static artwork and placeholders as fallbacks
- Use Motion Art for album heroes in `AnimatedAlbumArt`, skipping the Ken Burns effect when motion art is available
- Prefetch motion artwork for up to 8 albums on the Albums screen (metadata-only fetch, sequential with a 400ms gap to respect upstream rate limits, stops if motion art is disabled or unmounted)
- Update the "Animated Album Art" settings description

## Sibling / nearby artwork fallbacks

- Native sibling-artwork lookup in `MainActivity.kt` (121L) supporting common local and SAF document URIs, falling back to the next valid cover image
- `album_art_service.dart`: load nearby folder covers when artwork is missing, caching each folder cover once for album-track resolutions
- `music_folder_service.dart`: sibling artwork fetching for SAF folders

## Onboarding

- Use exact page transitions in onboarding: jump pages when normal animations are disabled, animate otherwise
- Add onboarding screen navigation test (45L)

## Release engineering

- Prepare `0.22.0-beta.1` pre-release: refactored `CHANGELOG.md` into the full release notes (DSD native playback, ReplayGain & crossfeed, karaoke lyrics, global search, scanning & permissions, engine recovery, navigation refresh, USB & Bluetooth, network sources, player & library), added `docs/RELEASE_0.22.0-beta.1.md`, and populated in-app What's New changelog data
- Bump version to `0.22.0-beta.1+27`
- Upgrade Android Gradle toolchain to AGP 9.1 and Gradle 9.3.1, applying Kotlin manually to `file_picker` and using `ExecOperations` in CargoKit for AGP 9 compatibility

## Files Changed

- `lib/features/player/widgets/motion_art_widget.dart` (new, 222L)
- `lib/services/motion_art/animated_artwork_service.dart` (new, 503L)
- `lib/services/motion_art/motion_art_album_matcher.dart` (new, 144L)
- `lib/features/player/widgets/album_art_box.dart`
- `lib/widgets/common/animated_album_art.dart`
- `lib/features/albums/screens/albums_screen.dart`, `album_detail_screen.dart`
- `lib/services/album_art_service.dart`, `music_folder_service.dart`
- `android/app/src/main/kotlin/.../MainActivity.kt` (+121L)
- `lib/features/onboarding/screens/onboarding_screen.dart`
- `test/features/onboarding/onboarding_screen_test.dart` (new)
- `test/services/motion_art_album_matcher_test.dart` (new, 173L)
- `test/services/album_art_service_test.dart`
- `CHANGELOG.md`, `docs/RELEASE_0.22.0-beta.1.md`, `lib/features/whats_new/data/changelog_data.dart`, `lib/core/constants/app_constants.dart`, `pubspec.yaml`
- `android/build.gradle.kts`, `android/gradle.properties`, `android/gradle/wrapper/gradle-wrapper.properties`, `android/settings.gradle.kts`, `rust_builder/cargokit/gradle/plugin.gradle`, `rust_builder/android/build.gradle`