### PR TITLE
Add portrait-oriented Motion Art backgrounds and vertical playback fallback

### DIFF
--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -512,6 +512,7 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
                 ? song.albumArtist
                 : song.artist,
             representativeSongTitle: song.title,
+            preferVertical: true,
           )
         : CachedImageWidget(
             imagePath: song.albumArt,

--- a/lib/features/player/widgets/motion_art_widget.dart
+++ b/lib/features/player/widgets/motion_art_widget.dart
@@ -22,6 +22,7 @@ class MotionArtView extends StatefulWidget {
     this.enabled = true,
     this.albumMode = false,
     this.representativeSongTitle,
+    this.preferVertical = false,
     this.fit = BoxFit.cover,
     this.borderRadius,
   });
@@ -40,6 +41,9 @@ class MotionArtView extends StatefulWidget {
   /// Resolve by album (edition-aware) rather than by song.
   final bool albumMode;
   final String? representativeSongTitle;
+
+  /// Prefer the portrait motion-art variant (full-bleed backgrounds).
+  final bool preferVertical;
 
   final BoxFit fit;
   final BorderRadius? borderRadius;
@@ -75,6 +79,7 @@ class _MotionArtViewState extends State<MotionArtView> {
         oldWidget.album != widget.album ||
         oldWidget.albumMode != widget.albumMode ||
         oldWidget.representativeSongTitle != widget.representativeSongTitle ||
+        oldWidget.preferVertical != widget.preferVertical ||
         oldWidget.enabled != widget.enabled;
     if (changed) _restart();
   }
@@ -142,7 +147,9 @@ class _MotionArtViewState extends State<MotionArtView> {
     }
 
     if (!mounted || generation != _generation) return;
-    final url = artwork?.playbackUrl;
+    final url = widget.preferVertical
+        ? artwork?.verticalPlaybackUrl
+        : artwork?.playbackUrl;
     if (url == null) {
       // Could be a definitive "no motion art" (cache hit, no network) or a
       // transient boidu 503; a bounded retry covers the transient case and is

--- a/lib/features/player/widgets/song_stage.dart
+++ b/lib/features/player/widgets/song_stage.dart
@@ -517,7 +517,7 @@ class SongStage extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final isShortHeight = constraints.maxHeight < 620;
-        final isVeryShortHeight = constraints.maxHeight < 540;
+        final isVeryShortHeight = constraints.maxHeight < 400;
         final horizontalPadding = constraints.maxWidth < 360
             ? 16.0
             : context.responsive(20.0, 28.0, 36.0);

--- a/lib/services/motion_art/animated_artwork_service.dart
+++ b/lib/services/motion_art/animated_artwork_service.dart
@@ -56,6 +56,20 @@ class AnimatedArtwork {
     return null;
   }
 
+  /// Portrait variant for full-bleed backgrounds, falling back to the square
+  /// playlist when the album only has square motion art.
+  String? get verticalPlaybackUrl {
+    for (final url in [
+      animatedVerticalUrl,
+      videoUrlVertical,
+      animatedUrl,
+      videoUrl,
+    ]) {
+      if (_has(url)) return url;
+    }
+    return null;
+  }
+
   factory AnimatedArtwork.fromJson(Map<String, dynamic> json) {
     String? str(Object? v) => v is String && v.trim().isNotEmpty ? v : null;
     return AnimatedArtwork(

--- a/lib/widgets/common/animated_album_art.dart
+++ b/lib/widgets/common/animated_album_art.dart
@@ -1,5 +1,3 @@
-import 'dart:ui' show ImageFilter;
-
 import 'package:flutter/material.dart';
 
 import 'package:flick/features/player/widgets/motion_art_widget.dart';
@@ -118,40 +116,15 @@ class _AnimatedAlbumArtState extends State<AnimatedAlbumArt>
     final artist = widget.artistName?.trim() ?? '';
     if (album.isEmpty || artist.isEmpty) return kenBurns;
 
-    final motion = MotionArtView(
+    return MotionArtView(
       title: album,
       album: album,
       artist: artist,
       albumMode: true,
       representativeSongTitle: widget.representativeSongTitle,
       preferVertical: widget.preferVertical,
-      fit: widget.preferVertical ? BoxFit.contain : BoxFit.cover,
       enabled: !MediaQuery.of(context).disableAnimations,
       fallback: kenBurns,
-    );
-
-    if (!widget.preferVertical) return motion;
-
-    // Portrait art is letterboxed on a tall screen; a blurred, zoomed copy of
-    // the same cover fills the exposed edges so there are no black bars.
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        ImageFiltered(
-          imageFilter: ImageFilter.blur(sigmaX: 28, sigmaY: 28),
-          child: Transform.scale(
-            scale: 1.2,
-            child: CachedImageWidget(
-              imagePath: widget.imagePath,
-              audioSourcePath: widget.audioSourcePath,
-              fit: BoxFit.cover,
-              placeholder: widget.placeholder,
-              errorWidget: widget.errorWidget,
-            ),
-          ),
-        ),
-        motion,
-      ],
     );
   }
 }

--- a/lib/widgets/common/animated_album_art.dart
+++ b/lib/widgets/common/animated_album_art.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show ImageFilter;
+
 import 'package:flutter/material.dart';
 
 import 'package:flick/features/player/widgets/motion_art_widget.dart';
@@ -21,6 +23,9 @@ class AnimatedAlbumArt extends StatefulWidget {
   final String? artistName;
   final String? representativeSongTitle;
 
+  /// Prefer the portrait motion-art variant (full-bleed backgrounds).
+  final bool preferVertical;
+
   const AnimatedAlbumArt({
     super.key,
     this.imagePath,
@@ -31,6 +36,7 @@ class AnimatedAlbumArt extends StatefulWidget {
     this.albumName,
     this.artistName,
     this.representativeSongTitle,
+    this.preferVertical = false,
   });
 
   @override
@@ -112,14 +118,40 @@ class _AnimatedAlbumArtState extends State<AnimatedAlbumArt>
     final artist = widget.artistName?.trim() ?? '';
     if (album.isEmpty || artist.isEmpty) return kenBurns;
 
-    return MotionArtView(
+    final motion = MotionArtView(
       title: album,
       album: album,
       artist: artist,
       albumMode: true,
       representativeSongTitle: widget.representativeSongTitle,
+      preferVertical: widget.preferVertical,
+      fit: widget.preferVertical ? BoxFit.contain : BoxFit.cover,
       enabled: !MediaQuery.of(context).disableAnimations,
       fallback: kenBurns,
+    );
+
+    if (!widget.preferVertical) return motion;
+
+    // Portrait art is letterboxed on a tall screen; a blurred, zoomed copy of
+    // the same cover fills the exposed edges so there are no black bars.
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        ImageFiltered(
+          imageFilter: ImageFilter.blur(sigmaX: 28, sigmaY: 28),
+          child: Transform.scale(
+            scale: 1.2,
+            child: CachedImageWidget(
+              imagePath: widget.imagePath,
+              audioSourcePath: widget.audioSourcePath,
+              fit: BoxFit.cover,
+              placeholder: widget.placeholder,
+              errorWidget: widget.errorWidget,
+            ),
+          ),
+        ),
+        motion,
+      ],
     );
   }
 }


### PR DESCRIPTION
# Summary

- Add a vertical (portrait) playback artwork fallback, with square artwork used when only that exists
- Improve motion art on tall screens by letterboxing and blurring a zoomed cover copy to fill exposed edges
- Consolidate landscape and portrait album art into `MotionArtView`, removing the custom `Stack` fallback

# Changes

- Add `verticalPlaybackUrl` getter to `AnimatedArtwork` in `animated_artwork_service.dart`: picks the portrait variant for full-bleed backgrounds, falling back through animated/video vertical then landscape URLs to square artwork
- Add `preferVertical` flag to `AnimatedAlbumArt` and a portrait-oriented background: `BoxFit.contain` letterboxing over a blurred, zoomed (1.2×, sigma 28) cover copy so tall screens have no black bars
- Replace the custom portrait `Stack`/`ImageFiltered`/`Transform.scale` fallback in `AnimatedAlbumArt` with `MotionArtView` for both orientations
- Lower the `SongStage` "very short height" threshold from 540 to 400 so portrait players keep the full-bleed artwork on more screens

# Files Changed

- `lib/widgets/common/animated_album_art.dart`
- `lib/services/motion_art/animated_artwork_service.dart`
- `lib/features/player/widgets/song_stage.dart`